### PR TITLE
Fix some warnings on OSX

### DIFF
--- a/src/extension/libmini_event.c
+++ b/src/extension/libmini_event.c
@@ -107,9 +107,9 @@ getdns_mini_event_run_once(getdns_eventloop *loop, int blocking)
 static getdns_return_t
 getdns_mini_event_clear(getdns_eventloop *loop, getdns_eventloop_event *el_ev)
 {
-	getdns_return_t r;
+	getdns_return_t r = GETDNS_RETURN_GOOD;
 	getdns_mini_event *ext = (getdns_mini_event *)loop;
-	
+
 	assert(el_ev->ev);
 
 	if (getdns_event_del(el_ev->ev) != 0)
@@ -161,7 +161,7 @@ getdns_mini_event_schedule(getdns_eventloop *loop,
 	    (el_ev->write_cb ? EV_WRITE|EV_PERSIST : 0) |
 	    (el_ev->timeout_cb ? EV_TIMEOUT : 0)),
 	    getdns_mini_event_callback, el_ev);
-	
+
 	if (getdns_mini_event_settime(ext))
 		goto error;
 

--- a/src/gldns/parseutil.c
+++ b/src/gldns/parseutil.c
@@ -14,6 +14,7 @@
 
 #include "config.h"
 #include "gldns/parseutil.h"
+#include <strings.h>
 #include <sys/time.h>
 #include <time.h>
 #include <ctype.h>
@@ -51,7 +52,7 @@ static const int mdays[] = {
 static int
 is_leap_year(int year)
 {
-	return GLDNS_MOD(year,   4) == 0 && (GLDNS_MOD(year, 100) != 0 
+	return GLDNS_MOD(year,   4) == 0 && (GLDNS_MOD(year, 100) != 0
 	    || GLDNS_MOD(year, 400) == 0);
 }
 
@@ -60,7 +61,7 @@ leap_days(int y1, int y2)
 {
 	--y1;
 	--y2;
-	return (GLDNS_DIV(y2,   4) - GLDNS_DIV(y1,   4)) - 
+	return (GLDNS_DIV(y2,   4) - GLDNS_DIV(y1,   4)) -
 	       (GLDNS_DIV(y2, 100) - GLDNS_DIV(y1, 100)) +
 	       (GLDNS_DIV(y2, 400) - GLDNS_DIV(y1, 400));
 }
@@ -120,7 +121,7 @@ static void
 gldns_mon_and_mday_from_year_and_yday(struct tm *result)
 {
 	int idays = result->tm_yday;
-	const int *mon_lengths = is_leap_year(result->tm_year) ? 
+	const int *mon_lengths = is_leap_year(result->tm_year) ?
 					leap_year_mdays : mdays;
 
 	result->tm_mon = 0;
@@ -347,14 +348,14 @@ gldns_b32_ntop_base(const uint8_t* src, size_t src_sz, char* dst, size_t dst_sz,
 	const char* b32 = extended_hex ?  "0123456789abcdefghijklmnopqrstuv"
 					: "abcdefghijklmnopqrstuvwxyz234567";
 
-	size_t c = 0; /* c is used to carry partial base32 character over 
+	size_t c = 0; /* c is used to carry partial base32 character over
 		       * byte boundaries for sizes with a remainder.
 		       * (i.e. src_sz % 5 != 0)
 		       */
 
 	ret_sz = add_padding ? gldns_b32_ntop_calculate_size(src_sz)
 			     : gldns_b32_ntop_calculate_size_no_padding(src_sz);
-	
+
 	/* Do we have enough space? */
 	if (dst_sz < ret_sz + 1)
 		return -1;
@@ -432,13 +433,13 @@ gldns_b32_ntop_base(const uint8_t* src, size_t src_sz, char* dst, size_t dst_sz,
 	return (int)ret_sz;
 }
 
-int 
+int
 gldns_b32_ntop(const uint8_t* src, size_t src_sz, char* dst, size_t dst_sz)
 {
 	return gldns_b32_ntop_base(src, src_sz, dst, dst_sz, 0, 1);
 }
 
-int 
+int
 gldns_b32_ntop_extended_hex(const uint8_t* src, size_t src_sz,
 		char* dst, size_t dst_sz)
 {
@@ -589,7 +590,7 @@ gldns_b32_pton(const char* src, size_t src_sz, uint8_t* dst, size_t dst_sz)
 }
 
 int
-gldns_b32_pton_extended_hex(const char* src, size_t src_sz, 
+gldns_b32_pton_extended_hex(const char* src, size_t src_sz,
 		uint8_t* dst, size_t dst_sz)
 {
 	return gldns_b32_pton_base(src, src_sz, dst, dst_sz, 1, 1);

--- a/src/gldns/rrdef.c
+++ b/src/gldns/rrdef.c
@@ -15,6 +15,7 @@
 #include "config.h"
 #include "gldns/rrdef.h"
 #include "gldns/parseutil.h"
+#include <strings.h>
 
 /* classes  */
 static gldns_lookup_table gldns_rr_classes_data[] = {
@@ -35,7 +36,7 @@ static const gldns_rdf_type type_md_wireformat[] = { GLDNS_RDF_TYPE_DNAME };
 static const gldns_rdf_type type_mf_wireformat[] = { GLDNS_RDF_TYPE_DNAME };
 static const gldns_rdf_type type_cname_wireformat[] = { GLDNS_RDF_TYPE_DNAME };
 static const gldns_rdf_type type_soa_wireformat[] = {
-	GLDNS_RDF_TYPE_DNAME, GLDNS_RDF_TYPE_DNAME, GLDNS_RDF_TYPE_INT32, 
+	GLDNS_RDF_TYPE_DNAME, GLDNS_RDF_TYPE_DNAME, GLDNS_RDF_TYPE_INT32,
 	GLDNS_RDF_TYPE_PERIOD, GLDNS_RDF_TYPE_PERIOD, GLDNS_RDF_TYPE_PERIOD,
 	GLDNS_RDF_TYPE_PERIOD
 };

--- a/src/util/mini_event.h
+++ b/src/util/mini_event.h
@@ -54,6 +54,8 @@
 
 #if defined(USE_MINI_EVENT) && !defined(USE_WINSOCK)
 
+#include <sys/select.h>
+
 #ifndef HAVE_EVENT_BASE_FREE
 #define HAVE_EVENT_BASE_FREE
 #endif 


### PR DESCRIPTION
Fixing some warnings during build on OSX 10.9.  There's still a warning in `src/gldns/str2wire.c` about `strlcpy` -  it's in /usr/include/string.h but within this define block:

`#if __DARWIN_C_LEVEL >= __DARWIN_C_FULL`
