### PR TITLE
Features/transport fallback

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -79,15 +79,15 @@ getdns_upstream_transports[GETDNS_UPSTREAM_TRANSPORTS] = {
 static in_port_t 
 getdns_port_array[GETDNS_UPSTREAM_TRANSPORTS] = {
 	GETDNS_PORT_DNS,
+	GETDNS_PORT_DNS_OVER_TLS,
 	GETDNS_PORT_DNS,
-	GETDNS_PORT_DNS_OVER_TLS
 };
 
 char*
 getdns_port_str_array[] = {
 	GETDNS_STR_PORT_DNS,
+	GETDNS_STR_PORT_DNS_OVER_TLS,
 	GETDNS_STR_PORT_DNS,
-	GETDNS_STR_PORT_DNS_OVER_TLS
 };
 
 /* Private functions */
@@ -937,6 +937,8 @@ getdns_context_destroy(struct getdns_context *context)
 
     if (context->namespaces)
         GETDNS_FREE(context->my_mf, context->namespaces);
+    if (context->dns_transports)
+        GETDNS_FREE(context->my_mf, context->dns_transports);
 	if(context->fchg_resolvconf)
 	{
 		if(context->fchg_resolvconf->prevstat)

--- a/src/context.c
+++ b/src/context.c
@@ -71,23 +71,23 @@ typedef struct host_name_addrs {
 
 static getdns_transport_list_t 
 getdns_upstream_transports[GETDNS_UPSTREAM_TRANSPORTS] = {
+	GETDNS_TRANSPORT_STARTTLS, // Define before TCP to ease fallback
 	GETDNS_TRANSPORT_TCP,
 	GETDNS_TRANSPORT_TLS,
-	GETDNS_TRANSPORT_STARTTLS
 };
 
 static in_port_t 
 getdns_port_array[GETDNS_UPSTREAM_TRANSPORTS] = {
 	GETDNS_PORT_DNS,
-	GETDNS_PORT_DNS_OVER_TLS,
 	GETDNS_PORT_DNS,
+	GETDNS_PORT_DNS_OVER_TLS
 };
 
 char*
 getdns_port_str_array[] = {
 	GETDNS_STR_PORT_DNS,
-	GETDNS_STR_PORT_DNS_OVER_TLS,
 	GETDNS_STR_PORT_DNS,
+	GETDNS_STR_PORT_DNS_OVER_TLS
 };
 
 /* Private functions */

--- a/src/context.c
+++ b/src/context.c
@@ -596,6 +596,8 @@ upstream_init(getdns_upstream *upstream,
 	(void) memcpy(&upstream->addr, ai->ai_addr, ai->ai_addrlen);
 
 	/* How is this upstream doing? */
+	upstream->writes_done = 0;
+	upstream->responses_recieved = 0;
 	upstream->to_retry =  2;
 	upstream->back_off =  1;
 
@@ -605,6 +607,7 @@ upstream_init(getdns_upstream *upstream,
 	upstream->starttls_req = NULL;
 	upstream->transport = GETDNS_TRANSPORT_TCP;
 	upstream->tls_hs_state = GETDNS_HS_NONE;
+	upstream->tcp.write_error = 0;
 	upstream->loop = NULL;
 	(void) getdns_eventloop_event_init(
 	    &upstream->event, upstream, NULL, NULL, NULL);

--- a/src/context.h
+++ b/src/context.h
@@ -86,6 +86,8 @@ typedef struct getdns_upstream {
 	struct sockaddr_storage  addr;
 
 	/* How is this upstream doing? */
+	size_t                   writes_done;
+	size_t                   responses_recieved;
 	int                      to_retry;
 	int                      back_off;
 

--- a/src/context.h
+++ b/src/context.h
@@ -91,7 +91,7 @@ typedef struct getdns_upstream {
 
 	/* For sharing a TCP socket to this upstream */
 	int                      fd;
-	getdns_base_transport_t  dns_base_transport;
+	getdns_transport_list_t  transport;
 	SSL*                     tls_obj;
 	getdns_tls_hs_state_t    tls_hs_state;
 	getdns_dns_req *         starttls_req;
@@ -138,9 +138,12 @@ struct getdns_context {
 	struct getdns_list   *suffix;
 	struct getdns_list   *dnssec_trust_anchors;
 	getdns_upstreams     *upstreams;
-	getdns_base_transport_t dns_base_transports[GETDNS_BASE_TRANSPORT_MAX];
 	uint16_t             limit_outstanding_queries;
 	uint32_t             dnssec_allowed_skew;
+
+	getdns_transport_list_t   *dns_transports;
+	size_t                     dns_transport_count;
+	size_t                     dns_transport_current;
 
 	uint8_t edns_extended_rcode;
 	uint8_t edns_version;

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -62,7 +62,6 @@ network_req_cleanup(getdns_network_req *net_req)
 	if (net_req->response && (net_req->response < net_req->wire_data ||
 	    net_req->response > net_req->wire_data+ net_req->wire_data_sz))
 		GETDNS_FREE(net_req->owner->my_mf, net_req->response);
-	GETDNS_FREE(net_req->owner->my_mf, net_req->transports);
 }
 
 static int
@@ -90,13 +89,10 @@ network_req_init(getdns_network_req *net_req, getdns_dns_req *owner,
 
 	net_req->upstream = NULL;
 	net_req->fd = -1;
-    net_req->transports = GETDNS_XMALLOC(net_req->owner->my_mf,
-                                        getdns_transport_list_t,
-                                        owner->context->dns_transport_count);
-    memcpy(owner->context->dns_transports, net_req->transports,
-        owner->context->dns_transport_count * sizeof(getdns_transport_list_t));
     net_req->transport_count = owner->context->dns_transport_count;
 	net_req->transport_current = 0;
+    memcpy(net_req->transports, owner->context->dns_transports,
+           net_req->transport_count * sizeof(getdns_transport_list_t));
 	memset(&net_req->event, 0, sizeof(net_req->event));
 	memset(&net_req->tcp, 0, sizeof(net_req->tcp));
 	net_req->query_id = 0;

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -62,6 +62,7 @@ network_req_cleanup(getdns_network_req *net_req)
 	if (net_req->response && (net_req->response < net_req->wire_data ||
 	    net_req->response > net_req->wire_data+ net_req->wire_data_sz))
 		GETDNS_FREE(net_req->owner->my_mf, net_req->response);
+	GETDNS_FREE(net_req->owner->my_mf, net_req->transports);
 }
 
 static int
@@ -89,9 +90,13 @@ network_req_init(getdns_network_req *net_req, getdns_dns_req *owner,
 
 	net_req->upstream = NULL;
 	net_req->fd = -1;
-	for (i = 0; i < GETDNS_BASE_TRANSPORT_MAX; i++)
-		net_req->dns_base_transports[i] = owner->context->dns_base_transports[i];
-	net_req->transport = 0;
+    net_req->transports = GETDNS_XMALLOC(net_req->owner->my_mf,
+                                        getdns_transport_list_t,
+                                        owner->context->dns_transport_count);
+    memcpy(owner->context->dns_transports, net_req->transports,
+        owner->context->dns_transport_count * sizeof(getdns_transport_list_t));
+    net_req->transport_count = owner->context->dns_transport_count;
+	net_req->transport_current = 0;
 	memset(&net_req->event, 0, sizeof(net_req->event));
 	memset(&net_req->tcp, 0, sizeof(net_req->tcp));
 	net_req->query_id = 0;

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -635,6 +635,7 @@ done_destroy_context:
 		return 0;
 	if (r)
 		fprintf(stderr, "An error occurred: %d\n", r);
+	fprintf(stdout, "\nAll done.\n");
 	return r;
 }
 

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -180,7 +180,7 @@ void callback(getdns_context *context, getdns_callback_type_t callback_type,
 			fprintf(stdout, "ASYNC response:\n%s\n", response_str);
 			free(response_str);
 		}
-		fprintf(stderr,
+		fprintf(stdout,
 			"Result:      The callback with ID %llu  was successfull.\n",
 			(unsigned long long)trans_id);
 
@@ -188,13 +188,14 @@ void callback(getdns_context *context, getdns_callback_type_t callback_type,
 		fprintf(stderr,
 			"Result:      The callback with ID %llu was cancelled. Exiting.\n",
 			(unsigned long long)trans_id);
-	else
+	else {
 		fprintf(stderr,
 			"Result:      The callback got a callback_type of %d. Exiting.\n",
 			callback_type);
 		fprintf(stderr,
 			"Error :      '%s'\n",
 			getdns_get_errorstr_by_id(callback_type));
+	}
 	getdns_dict_destroy(response);
 	response = NULL;
 }

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -443,7 +443,7 @@ getdns_return_t parse_args(int argc, char **argv)
 					return GETDNS_RETURN_GENERIC_ERROR;
 				}
 				size_t transport_count = 0;
-				getdns_transport_list_t transports[GETDNS_BASE_TRANSPORT_MAX];
+				getdns_transport_list_t transports[strlen(argv[])];
 				if ((r = fill_transport_list(context, argv[i], transports, &transport_count)) ||
 				    (r = getdns_context_set_dns_transport_list(context, 
 				                                               transport_count, transports))){

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -443,7 +443,7 @@ getdns_return_t parse_args(int argc, char **argv)
 					return GETDNS_RETURN_GENERIC_ERROR;
 				}
 				size_t transport_count = 0;
-				getdns_transport_list_t transports[strlen(argv[])];
+				getdns_transport_list_t transports[GETDNS_TRANSPORTS_MAX];
 				if ((r = fill_transport_list(context, argv[i], transports, &transport_count)) ||
 				    (r = getdns_context_set_dns_transport_list(context, 
 				                                               transport_count, transports))){

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -159,6 +159,7 @@ typedef struct getdns_tcp_state {
 	uint8_t *write_buf;
 	size_t   write_buf_len;
 	size_t   written;
+	int      write_error;
 
 	uint8_t *read_buf;
 	size_t   read_buf_len;
@@ -167,17 +168,6 @@ typedef struct getdns_tcp_state {
 
 } getdns_tcp_state;
 
-// /* TODO[TLS]: change this name to getdns_transport when API updated*/
-// typedef enum getdns_base_transport {
-// 	GETDNS_TRANSPORT_MIN   = 0,
-// 	GETDNS_TRANSPORT_NONE  = 0,
-// 	GETDNS_TRANSPORT_UDP,
-// 	GETDNS_TRANSPORT_TCP_SINGLE, /* To be removed? */
-// 	GETDNS_TRANSPORT_STARTTLS,   /* Define before TCP to allow fallback */
-// 	GETDNS_TRANSPORT_TCP,
-// 	GETDNS_TRANSPORT_TLS,
-// 	GETDNS_TRANSPORT_MAX
-// } getdns_base_transport_t;
 
 /**
  * Request data

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -99,6 +99,9 @@ struct getdns_upstream;
 #define TIMEOUT_FOREVER ((int64_t)-1)
 #define ASSERT_UNREACHABLE 0
 
+#define GETDNS_TRANSPORTS_MAX 4
+#define GETDNS_UPSTREAM_TRANSPORTS 3
+
 /** @}
  */
 
@@ -164,17 +167,17 @@ typedef struct getdns_tcp_state {
 
 } getdns_tcp_state;
 
-/* TODO[TLS]: change this name to getdns_transport when API updated*/
-typedef enum getdns_base_transport {
-	GETDNS_BASE_TRANSPORT_MIN   = 0,
-	GETDNS_BASE_TRANSPORT_NONE  = 0,
-	GETDNS_BASE_TRANSPORT_UDP,
-	GETDNS_BASE_TRANSPORT_TCP_SINGLE, /* To be removed? */
-	GETDNS_BASE_TRANSPORT_STARTTLS,   /* Define before TCP to allow fallback */
-	GETDNS_BASE_TRANSPORT_TCP,
-	GETDNS_BASE_TRANSPORT_TLS,
-	GETDNS_BASE_TRANSPORT_MAX
-} getdns_base_transport_t;
+// /* TODO[TLS]: change this name to getdns_transport when API updated*/
+// typedef enum getdns_base_transport {
+// 	GETDNS_TRANSPORT_MIN   = 0,
+// 	GETDNS_TRANSPORT_NONE  = 0,
+// 	GETDNS_TRANSPORT_UDP,
+// 	GETDNS_TRANSPORT_TCP_SINGLE, /* To be removed? */
+// 	GETDNS_TRANSPORT_STARTTLS,   /* Define before TCP to allow fallback */
+// 	GETDNS_TRANSPORT_TCP,
+// 	GETDNS_TRANSPORT_TLS,
+// 	GETDNS_TRANSPORT_MAX
+// } getdns_base_transport_t;
 
 /**
  * Request data
@@ -203,8 +206,9 @@ typedef struct getdns_network_req
 	/* For stub resolving */
 	struct getdns_upstream *upstream;
 	int                     fd;
-	getdns_base_transport_t dns_base_transports[GETDNS_BASE_TRANSPORT_MAX];
-	int                     transport;
+	getdns_transport_list_t *transports;
+	size_t                   transport_count;
+	size_t                   transport_current;
 	getdns_eventloop_event  event;
 	getdns_tcp_state        tcp;
 	uint16_t                query_id;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -206,7 +206,7 @@ typedef struct getdns_network_req
 	/* For stub resolving */
 	struct getdns_upstream *upstream;
 	int                     fd;
-	getdns_transport_list_t *transports;
+	getdns_transport_list_t transports[GETDNS_TRANSPORTS_MAX];
 	size_t                   transport_count;
 	size_t                   transport_current;
 	getdns_eventloop_event  event;


### PR DESCRIPTION
Re-factor of transport to better align with new API:
- renaming of transport internals and option storage
- remove single shot TCP implementation
- add idle time handlers. Can't use variable idle time in sync mode and connections are shut too aggressively at the moment.
- start work on re-factor of schedule handling and fallback
- detect TCP failures on write better to trigger fallback. This is too simplistic and needs improving.
- fixed lots of bugs in the sync code
- fixed bug with upstream selection handling that has been causing an intermittent crash
- extended getdns_query to help out with testing