### PR TITLE
Features/tls auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 src/config.h.in
+build/

--- a/INSTALL
+++ b/INSTALL
@@ -254,10 +254,11 @@ not `/usr/local'.  It is recommended to use the following options:
 
      ./configure --prefix=/boot/common
 
-   On Mac OSX getdns will not build against the version of OpenSSL shipped with 
+   On Mac OSX getdns will not build against the version of OpenSSL shipped with
 OSX. If you link against a self-complied version of OpenSSL then manual 
-configuration of certificates is required for TLS authentication to work, 
-however if linking against the version of OpenSSL installed via Homebrew TLS 
+configuration of certificates into the default OpenSSL directory 
+/usr/local/etc/openssl/certs is currently required for TLS authentication to work.
+However if linking against the version of OpenSSL installed via Homebrew TLS 
 authentication will work out of the box.
 
 Specifying the System Type

--- a/INSTALL
+++ b/INSTALL
@@ -254,6 +254,12 @@ not `/usr/local'.  It is recommended to use the following options:
 
      ./configure --prefix=/boot/common
 
+   On Mac OSX getdns will not build against the version of OpenSSL shipped with 
+OSX. If you link against a self-complied version of OpenSSL then manual 
+configuration of certificates is required for TLS authentication to work, 
+however if linking against the version of OpenSSL installed via Homebrew TLS 
+authentication will work out of the box.
+
 Specifying the System Type
 ==========================
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ External dependencies are linked outside the getdns API build tree (we rely on c
 * [libunbound from NLnet Labs](http://www.nlnetlabs.nl/projects/unbound/) version 1.4.16 or later
 * [libexpat](http://expat.sourceforge.net/) for libunbound.
 * [libidn from the FSF](http://www.gnu.org/software/libidn/) version 1.
+* [libopenssl from the OpenSSL Project](https://www.openssl.org/) version 0.9.7 or later. (Note: version 1.0.2 or later is required for TLS support)
 * Doxygen is used to generate documentation, while this is not technically necessary for the build it makes things a lot more pleasant.
 
 You have to install the library and also the library-devel (or -dev) for your
@@ -148,8 +149,6 @@ Some platform specific features are not implemented in the first public release 
 There are a few known issues which we have summarized below - the most recent
 and helpful list is being maintained in the git issues list in the repository.
 Other known issues are being managed in the git repository issue list.
-
-* (#113) Changing the resolution type between stub and recursive after a query has been issued with a context will not work - the previous resolution type will continue to be used.  If you want to change the resolution type you will need to create a new context and set the resolution type for that context.
 
 * When doing a synchronous lookup with a context that has outstanding asynchronous lookups, the callbacks for the asynchronous lookups might get called as a side effect of the synchronous lookup.
 
@@ -214,6 +213,9 @@ build the packages, this is simplythe one we chose to use.
 
     create dmg
 
+    A self-compiled version of OpenSSL or the version installed via Homebrew is required.
+    Note: If using a self-compiled version manual configuration of certificates is required for TLS authentication to wokr
+
 #### Homebrew
 
 If you're using [Homebrew](http://brew.sh/), you may run `brew install getdns`.  By default, this will only build the core library without any 3rd party event loop support.
@@ -222,7 +224,7 @@ To install the [event loop integration libraries](https://github.com/getdnsapi/g
 
 Note that in order to compile the examples, the `--with-libevent` switch is required.
 
-As of the 0.2.0 release, when installing via Homebrew, the trust anchor is expected to be located at `$(brew --prefix)/etc/getdns-root.key`.  Additionally, the openssl lib installed by Homebrew is linked against.
+As of the 0.2.0 release, when installing via Homebrew, the trust anchor is expected to be located at `$(brew --prefix)/etc/getdns-root.key`.  Additionally, the OpenSSL library installed by Homebrew is linked against. Note that the Homebrew OpenSSL installation clones the Keychain certificates to the default OpenSSL location so TLS authentication should work out of the box.
 
 Contributors
 ============

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ External dependencies are linked outside the getdns API build tree (we rely on c
 * [libunbound from NLnet Labs](http://www.nlnetlabs.nl/projects/unbound/) version 1.4.16 or later
 * [libexpat](http://expat.sourceforge.net/) for libunbound.
 * [libidn from the FSF](http://www.gnu.org/software/libidn/) version 1.
-* [libopenssl from the OpenSSL Project](https://www.openssl.org/) version 0.9.7 or later. (Note: version 1.0.2 or later is required for TLS support)
+* [libssl from the OpenSSL Project](https://www.openssl.org/) version 0.9.7 or later. (Note: version 1.0.2 or later is required for TLS support)
 * Doxygen is used to generate documentation, while this is not technically necessary for the build it makes things a lot more pleasant.
 
 You have to install the library and also the library-devel (or -dev) for your

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ build the packages, this is simplythe one we chose to use.
     create dmg
 
     A self-compiled version of OpenSSL or the version installed via Homebrew is required.
-    Note: If using a self-compiled version manual configuration of certificates is required for TLS authentication to wokr
+    Note: If using a self-compiled version manual configuration of certificates into /usr/local/etc/openssl/certs is required for TLS authentication to work.
 
 #### Homebrew
 

--- a/build/src/test/tests_transports.sh
+++ b/build/src/test/tests_transports.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SERVER_IP="8.8.8.8"
+TLS_SERVER_IP="185.49.141.38"
+GOOD_RESULT_SYNC="Status was: At least one response was returned"
+GOOD_RESULT_ASYNC="successfull"
+BAD_RESULT_SYNC="1 'Generic error'"
+BAD_RESULT_ASYNC="callback_type of 703"
+GOOD_COUNT=0
+FAIL_COUNT=0
+
+check_good () {
+	result=`echo $1 | grep "Response code was: GOOD." | tail -1 | sed 's/ All done.'// | sed 's/Response code was: GOOD. '//`
+	async_success=`echo $result | grep -c "$GOOD_RESULT_ASYNC"`
+	if [[ $result =~ $GOOD_RESULT_SYNC ]] || [[ $async_success =~ 1 ]]; then
+			(( GOOD_COUNT++ ))
+			echo -n "PASS: "
+		else
+			(( FAIL_COUNT++ ))
+			echo "FAIL (RESULT): " $1
+			echo -n "FAIL: "
+	fi
+}
+
+check_bad () {
+	result=`echo $1 | grep "An error occurred:" | tail -1 | sed 's/ All done.'//`
+	error=` echo $result | sed 's/An error occurred: //'`
+	if [[ ! -z $result ]]; then
+		if [[ $error =~ $BAD_RESULT_SYNC ]] || [[ $error =~ $BAD_RESULT_ASYNC ]]; then
+				(( GOOD_COUNT++ ))
+				echo -n "PASS:"
+			else
+				(( FAIL_COUNT++ ))
+				echo "FAIL (RESULT): " $error
+				echo -n "FAIL: "
+		fi
+	else
+		(( FAIL_COUNT++ ))
+		echo "FAIL (RESULT): " $1
+		echo -n "FAIL: "
+	fi
+}
+
+usage () {
+	echo "This is a basic and temporary testing script for the transport list"
+	echo "functionality that utilises getdns_query to perform multiple queries."
+	echo "It will be replaced by an automated test harness in future, but"
+	echo "it can be used to check the basic functionality for now. It is recommended that"
+	echo "local or known test servers are used, but it should work with the default servers:"
+	echo " - Google Open DNS for TCP and UDP only "
+	echo  "- the getdnsapi.net test server Open Resolver for TLS, STARTTLS, TCP and UDP"
+	echo
+	echo "usage: test_transport.sh"
+	echo "         -s   server configured for only TCP and UDP"
+	echo "         -t   server configured for TLS, STARTTLS, TCP and UDP"
+}
+
+while getopts ":s:t:dh" opt; do
+	case $opt in
+		d ) set -x ;;
+		s ) SERVER_IP=$OPTARG ; echo "Setting server to $OPTARG" ;;
+		t ) TLS_SERVER_IP=$OPTARG ; echo "Setting TLS server to $OPTARG" ;;
+		h ) usage ; exit ;;
+	esac
+done
+
+GOOD_QUERIES=(
+"-s -A -q getdnsapi.net -l U      @${SERVER_IP}    "
+"-s -A -q getdnsapi.net -l T      @${SERVER_IP}    "
+"-s -A -q getdnsapi.net -l L      @${TLS_SERVER_IP}"
+"-s -A -q getdnsapi.net -l S      @${TLS_SERVER_IP}")
+
+GOOD_FALLBACK_QUERIES=(
+"-s -A -q getdnsapi.net -l LT     @${SERVER_IP}"
+"-s -A -q getdnsapi.net -l LU     @${SERVER_IP}"
+"-s -A -q getdnsapi.net -l L      @${SERVER_IP} @${TLS_SERVER_IP}"
+"-s -G -q DNSKEY getdnsapi.net -l UT  @${SERVER_IP} -b 512 -D")
+
+NOT_AVAILABLE_QUERIES=(
+"-s -A -q getdnsapi.net -l L      @${SERVER_IP}    "
+"-s -A -q getdnsapi.net -l S      @${SERVER_IP}    "
+"-s -G -q DNSKEY getdnsapi.net -l U   @${SERVER_IP} -b 512 -D")
+
+echo "Starting transport test"
+echo
+for (( i = 0; i < 2; i+=1 )); do
+	if [[ i -eq 0 ]]; then
+		echo "**SYNC Mode**"
+	else
+		echo
+		echo "**ASYNC Mode**"
+		SYNC_MODE=" -a "
+	fi
+
+	echo "*Success cases:"
+	for (( j = 0; j < ${#GOOD_QUERIES[@]}; j+=1 )); do
+		check_good "`$DIR/getdns_query $SYNC_MODE ${GOOD_QUERIES[${j}]} 2>/dev/null`"
+		echo "getdns_query $SYNC_MODE ${GOOD_QUERIES[${j}]}"
+		(( COUNT++ ))
+	done
+	
+	echo "*Success fallback cases:"
+	for (( j = 0; j < ${#GOOD_FALLBACK_QUERIES[@]}; j+=1 )); do
+		check_good "`$DIR/getdns_query $SYNC_MODE ${GOOD_FALLBACK_QUERIES[${j}]} 2>/dev/null`"
+		echo "getdns_query $SYNC_MODE ${GOOD_FALLBACK_QUERIES[${j}]}"
+		(( COUNT++ ))
+	done
+
+	echo "*Transport not available cases:"
+	for (( j = 0; j < ${#NOT_AVAILABLE_QUERIES[@]}; j+=1 )); do
+		check_bad "`$DIR/getdns_query $SYNC_MODE ${NOT_AVAILABLE_QUERIES[${j}]} 2>&1`"
+		echo "getdns_query $SYNC_MODE ${NOT_AVAILABLE_QUERIES[${j}]}"
+		(( COUNT++ ))
+	done
+done
+
+echo
+echo "Finished transport test: did $COUNT queries, $GOOD_COUNT passes, $FAIL_COUNT failures"
+echo

--- a/m4/acx_openssl.m4
+++ b/m4/acx_openssl.m4
@@ -105,8 +105,9 @@ AC_DEFUN([ACX_SSL_CHECKS], [
 AC_CHECK_HEADERS([openssl/ssl.h],,, [AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS([openssl/err.h],,, [AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS([openssl/rand.h],,, [AC_INCLUDES_DEFAULT])
-AC_CHECK_LIB(ssl, TLSv1_2_client_method,AC_DEFINE([HAVE_LIBTLS1_2], [1],
-    [Define if you have libssl with tls 1.2]),[AC_MSG_WARN([Cannot find TLSv1_2_client_method in libssl library. TLS will not be available.])])
+dnl Authentication now requires 1.0.2, which supports TLSv1.2
+AC_CHECK_LIB(ssl, SSL_CTX_get0_param,AC_DEFINE([HAVE_LIBSSL_102], [1],
+    [Define if you have libssl 1.0.2 or later]),[AC_MSG_WARN([libssl 1.0.2 or higher is required for TLS authentication. TLS will not be available.])])
 ])dnl End of ACX_SSL_CHECKS
 
 dnl Check for SSL, where SSL is mandatory

--- a/spec/index.html
+++ b/spec/index.html
@@ -2209,7 +2209,9 @@ getdns_context_set_dns_transport_list(
 <p class=cont>The <code>transports</code> array contains an ordered list of transports that will be used for DNS lookups.
 If only one transport value is specified it will be the only transport used.
 Should it not be available basic resolution will fail.
-Fallback transport options are specified by including multiple values in the list.
+Fallback transport options are specified by including multiple values in the list. Currently the TLS and STARTTLS options
+perform Strict TLS which requires a hostname to be 
+specified so that authentication can be performed. This hostname can be specified in the tls_auth_name parameter for an upstream.
 The values are <span class=default>
 <code>GETDNS_TRANSPORT_UDP</code></span>,
 <code>GETDNS_TRANSPORT_TCP</code>,

--- a/src/context.c
+++ b/src/context.c
@@ -1764,7 +1764,8 @@ getdns_context_set_upstream_recursive_servers(struct getdns_context *context,
 			upstream->addr.ss_family = addr.ss_family;
 			upstream_init(upstream, upstreams, ai);
 			upstream->transport = getdns_upstream_transports[j];
-			if (getdns_upstream_transports[j] == GETDNS_TRANSPORT_TLS) {
+			if (getdns_upstream_transports[j] == GETDNS_TRANSPORT_TLS ||
+			    getdns_upstream_transports[j] == GETDNS_TRANSPORT_STARTTLS) {
 				if ((r = getdns_dict_get_bindata(
 					dict, "tls_auth_name", &tls_auth_name)) == GETDNS_RETURN_GOOD) {
 					/*TODO: VALIDATE THIS STRING!*/

--- a/src/context.c
+++ b/src/context.c
@@ -2164,7 +2164,7 @@ getdns_context_prepare_for_resolution(struct getdns_context *context,
 	if (context->resolution_type == GETDNS_RESOLUTION_STUB) {
 		if (tls_is_in_transports_list(context) == 1 &&
 		    context->tls_ctx == NULL) {
-#ifdef HAVE_LIBTLS1_2
+#ifdef HAVE_LIBSSL_102
 			/* Create client context, use TLS v1.2 only for now */
 			context->tls_ctx = SSL_CTX_new(TLSv1_2_client_method());
 #endif

--- a/src/context.c
+++ b/src/context.c
@@ -1217,16 +1217,20 @@ getdns_set_base_dns_transports(
 	if (!context || transport_count == 0 || transports == NULL)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	/* TODO: restrict the use of each transport to once ->
-	   sane list and correct max size for array*/
+	/* Check for valid transports and that they are used only once*/
+	int u=0,t=0,l=0,s=0;
 	for(i=0; i<transport_count; i++)
 	{
-		if( transports[i] != GETDNS_TRANSPORT_UDP
-		 && transports[i] != GETDNS_TRANSPORT_TCP
-		 && transports[i] != GETDNS_TRANSPORT_TLS
-		 && transports[i] != GETDNS_TRANSPORT_STARTTLS)
-			return GETDNS_RETURN_INVALID_PARAMETER;
+		switch (transports[i]) {
+			case GETDNS_TRANSPORT_UDP:       u++; break;
+			case GETDNS_TRANSPORT_TCP:       t++; break;
+			case GETDNS_TRANSPORT_TLS:       l++; break;
+			case GETDNS_TRANSPORT_STARTTLS:  s++; break;
+			default: return GETDNS_RETURN_INVALID_PARAMETER;
+		}
 	}
+	if ( u>1 || t>1 || l>1 || s>1)
+		return GETDNS_RETURN_INVALID_PARAMETER;
 	
 	if (!(new_transports = GETDNS_XMALLOC(context->my_mf,
 				getdns_transport_list_t, transport_count)))

--- a/src/context.h
+++ b/src/context.h
@@ -101,6 +101,7 @@ typedef struct getdns_upstream {
 	getdns_eventloop_event   event;
 	getdns_eventloop        *loop;
 	getdns_tcp_state         tcp;
+	char                     tls_auth_name[256];
 
 	/* Pipelining of TCP network requests */
 	getdns_network_req      *write_queue;

--- a/src/stub.c
+++ b/src/stub.c
@@ -825,6 +825,7 @@ tls_failed(getdns_upstream *upstream)
 static SSL*
 tls_create_object(getdns_context *context, int fd, const char* auth_name)
 {
+#ifdef HAVE_LIBSSL_102
 	/* Create SSL instance */
 	if (context->tls_ctx == NULL || auth_name == NULL)
 		return NULL;
@@ -845,6 +846,9 @@ tls_create_object(getdns_context *context, int fd, const char* auth_name)
 	SSL_set_connect_state(ssl);
 	(void) SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
 	return ssl;
+#else
+	return NULL;
+#endif
 }
 
 static int

--- a/src/stub.c
+++ b/src/stub.c
@@ -826,7 +826,7 @@ static SSL*
 tls_create_object(getdns_context *context, int fd, const char* auth_name)
 {
 	/* Create SSL instance */
-	if (context->tls_ctx == NULL)
+	if (context->tls_ctx == NULL || auth_name == NULL)
 		return NULL;
 	SSL* ssl = SSL_new(context->tls_ctx);
 	X509_VERIFY_PARAM *param;
@@ -896,6 +896,7 @@ tls_do_handshake(getdns_upstream *upstream)
 				upstream->tls_hs_state = GETDNS_HS_WRITE;
 				return STUB_TCP_AGAIN;
 			default:
+				DEBUG_STUB("--- %s %s %d\n", __FUNCTION__, "Handshake failed: ", want);
 				return tls_cleanup(upstream);
 	   }
 	}

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -55,6 +55,7 @@ ipaddr_dict(getdns_context *context, char *ipstr)
 	char *s = strchr(ipstr, '%'), *scope_id_str = "";
 	char *p = strchr(ipstr, '@'), *portstr = "";
 	char *t = strchr(ipstr, '#'), *tls_portstr = "";
+	char *n = strchr(ipstr, '~'), *tls_namestr = "";
 	uint8_t buf[sizeof(struct in6_addr)];
 	getdns_bindata addr;
 
@@ -72,6 +73,10 @@ ipaddr_dict(getdns_context *context, char *ipstr)
 	if (t) {
 		*t = 0;
 		tls_portstr = t + 1;
+	}
+	if (n) {
+		*n = 0;
+		tls_namestr = n + 1;
 	}
 	if (strchr(ipstr, ':')) {
 		getdns_dict_util_set_string(r, "address_type", "IPv6");
@@ -93,6 +98,9 @@ ipaddr_dict(getdns_context *context, char *ipstr)
 		getdns_dict_set_int(r, "port", (int32_t)atoi(portstr));
 	if (*tls_portstr)
 		getdns_dict_set_int(r, "tls_port", (int32_t)atoi(tls_portstr));
+	if (*tls_namestr) {
+		getdns_dict_util_set_string(r, "tls_auth_name", tls_namestr);
+	}
 	if (*scope_id_str)
 		getdns_dict_util_set_string(r, "scope_id", scope_id_str);
 

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -272,16 +272,16 @@ void callback(getdns_context *context, getdns_callback_type_t callback_type,
 			free(response_str);
 		}
 		fprintf(stdout,
-			"Result:      The callback with ID %llu  was successfull.\n",
+			"Response code was: GOOD. Status was: Callback with ID %llu  was successfull.\n",
 			(unsigned long long)trans_id);
 
 	} else if (callback_type == GETDNS_CALLBACK_CANCEL)
 		fprintf(stderr,
-			"Result:      The callback with ID %llu was cancelled. Exiting.\n",
+			"An error occurred: The callback with ID %llu was cancelled. Exiting.\n",
 			(unsigned long long)trans_id);
 	else {
 		fprintf(stderr,
-			"Result:      The callback got a callback_type of %d. Exiting.\n",
+			"An error occurred: The callback got a callback_type of %d. Exiting.\n",
 			callback_type);
 		fprintf(stderr,
 			"Error :      '%s'\n",

--- a/src/test/tests_transports.sh
+++ b/src/test/tests_transports.sh
@@ -2,7 +2,7 @@
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SERVER_IP="8.8.8.8"
-TLS_SERVER_IP="185.49.141.38"
+TLS_SERVER_IP="185.49.141.38~www.dnssec-name-and-shame.com"
 GOOD_RESULT_SYNC="Status was: At least one response was returned"
 GOOD_RESULT_ASYNC="successfull"
 BAD_RESULT_SYNC="1 'Generic error'"
@@ -58,6 +58,7 @@ usage () {
 	ehco "         -p   path to getdns_query binary"
 	echo "         -s   server configured for only TCP and UDP"
 	echo "         -t   server configured for TLS, STARTTLS, TCP and UDP"
+	echo "              (This must include the hostname e.g. 185.49.141.38~www.dnssec-name-and-shame.com)"
 }
 
 while getopts ":p:s:t:dh" opt; do
@@ -70,6 +71,9 @@ while getopts ":p:s:t:dh" opt; do
 	esac
 done
 
+TLS_SERVER_IP_NO_NAME=`echo ${TLS_SERVER_IP%~*}`
+echo $TLS_SERVER_IP_NO_NAME
+
 GOOD_QUERIES=(
 "-s -A -q getdnsapi.net -l U      @${SERVER_IP}    "
 "-s -A -q getdnsapi.net -l T      @${SERVER_IP}    "
@@ -78,13 +82,15 @@ GOOD_QUERIES=(
 
 GOOD_FALLBACK_QUERIES=(
 "-s -A -q getdnsapi.net -l LT     @${SERVER_IP}"
-"-s -A -q getdnsapi.net -l LU     @${SERVER_IP}"
+"-s -A -q getdnsapi.net -l LT     @${SERVER_IP}"
+"-s -A -q getdnsapi.net -l LT     @${TLS_SERVER_IP_NO_NAME}"
 "-s -A -q getdnsapi.net -l L      @${SERVER_IP} @${TLS_SERVER_IP}"
 "-s -G -q DNSKEY getdnsapi.net -l UT  @${SERVER_IP} -b 512 -D")
 
 NOT_AVAILABLE_QUERIES=(
 "-s -A -q getdnsapi.net -l L      @${SERVER_IP}    "
 "-s -A -q getdnsapi.net -l S      @${SERVER_IP}    "
+"-s -A -q getdnsapi.net -l L      @${TLS_SERVER_IP_NO_NAME}    "
 "-s -G -q DNSKEY getdnsapi.net -l U   @${SERVER_IP} -b 512 -D")
 
 echo "Starting transport test"

--- a/src/test/tests_transports.sh
+++ b/src/test/tests_transports.sh
@@ -50,15 +50,20 @@ usage () {
 	echo "local or known test servers are used, but it should work with the default servers:"
 	echo " - Google Open DNS for TCP and UDP only "
 	echo  "- the getdnsapi.net test server Open Resolver for TLS, STARTTLS, TCP and UDP"
+	echo "NOTE: By default this script assumes it is located in the same directory"
+	echo "as the getdns_query binary. If it is not, then the location of the binary"
+	echo "can be specified via the command line option."
 	echo
 	echo "usage: test_transport.sh"
+	ehco "         -p   path to getdns_query binary"
 	echo "         -s   server configured for only TCP and UDP"
 	echo "         -t   server configured for TLS, STARTTLS, TCP and UDP"
 }
 
-while getopts ":s:t:dh" opt; do
+while getopts ":p:s:t:dh" opt; do
 	case $opt in
 		d ) set -x ;;
+		p ) DIR=$OPTARG ;;
 		s ) SERVER_IP=$OPTARG ; echo "Setting server to $OPTARG" ;;
 		t ) TLS_SERVER_IP=$OPTARG ; echo "Setting TLS server to $OPTARG" ;;
 		h ) usage ; exit ;;


### PR DESCRIPTION
Add strict TLS authentication using hostname. 

1) User _must_ specify the hostname of the upstream (using tls_auth_name) as now TLS will use it to try to authenticate the server. If this fails then the TLS connection fails (a future update will add fallback to opportunistic TLS if authentication fails). 

2) Note that getdns is coded to expect the trusted CA certificates to be in the default directory for the OS, as specified by the SSL_CTX_set_default_verify_paths() method. We should consider adding an option for the user to specify this path.  This is a bit awkward on Mac OSX (see docs)...