### PR TITLE
Fix directory creation documentation for anchor file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -72,7 +72,7 @@ install: all
 	@echo "***"
 	@echo "***  We recomend using unbound-anchor to retrieve and install"
 	@echo "***  the root trust anchor like this: "
-	@echo "***        mkdir /etc/unbound"
+	@echo "***        mkdir -p `dirname @TRUST_ANCHOR_FILE@`"
 	@echo "***        unbound-anchor -a \"@TRUST_ANCHOR_FILE@\""
 	@echo "***"
 	@echo "***  We strongly recommend package maintainers to provide the"


### PR DESCRIPTION
I used `./configure --prefix` and the scary documentation about having an anchor file told me to put it in the directory I specified, but the directory creation would not work as documented. I hacked up a version which should work in the general case.