### PR TITLE
Don't treat "domain" or "search" as a nameserver.

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -864,8 +864,9 @@ set_os_defaults(struct getdns_context *context)
 			*token = 0;
 
 			(void) strlcpy(domain, parse, sizeof(domain));
-
-		} else if (strncmp(parse, "search", 6) == 0) {
+			continue;
+		}
+		if (strncmp(parse, "search", 6) == 0) {
 			parse += 6;
 			do {
 				parse += strspn(parse, " \t");
@@ -879,8 +880,9 @@ set_os_defaults(struct getdns_context *context)
 				*token = prev_ch;
 				parse = token;
 			} while (*parse);
-
-		} else if (strncmp(parse, "nameserver", 10) != 0)
+			continue;
+		}
+		if (strncmp(parse, "nameserver", 10) != 0)
 			continue;
 
 		parse += 10;


### PR DESCRIPTION
Continue the while fgets() loop as soon as we're done with "domain" or
"search".

Simplify the logic of the function by removing the if else constructs.