### PR TITLE
Features/wire2reply

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -384,9 +384,6 @@ getdns-specific Options
 `--with-libidn=pathname'
 	path to libidn (default: search /usr/local ..)
 
-`--with-libldns=pathname'
-	path to libldns (default: search /usr/local ..)
-
 `--with-libunbound=pathname'
 	path to libunbound (default: search /usr/local ..)
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ NOTE: The current Windows implementation does not support the above.
 
 A suite of regression tests are included with the library, if you make changes or just
 want to sanity check things on your system take a look at src/test.  You will need
-to install [libcheck](https://libcheck.github.io/check/) and [libldns from NLnet Labs](https://nlnetlabs.nl/projects/ldns/) version 1.6.17 or later.  Both libraries are also available from
+to install [libcheck](https://libcheck.github.io/check/).  The check library is also available from
 many of the package repositories for the more popular operating systems.
 
 NOTE: The current Windows implementation does not support the above.
@@ -198,7 +198,7 @@ build the packages, this is simplythe one we chose to use.
     # cd /home/deploy/build
     # mv lib lib64
     # . /usr/local/rvm/config/alias
-    # fpm -x "*.la" -a native -s dir -t rpm -n getdns -v 0.2.0rc1 -d "unbound" -d "ldns" -d "libevent" -d "libidn" --prefix /usr --vendor "Verisign Inc., NLnet Labs" --license "BSD New" --url "https://getdnsapi.net" --description "Modern asynchronous API to the DNS" .
+    # fpm -x "*.la" -a native -s dir -t rpm -n getdns -v 0.2.0rc1 -d "unbound" -d "libevent" -d "libidn" --prefix /usr --vendor "Verisign Inc., NLnet Labs" --license "BSD New" --url "https://getdnsapi.net" --description "Modern asynchronous API to the DNS" .
 
 ###OSX
 

--- a/configure.ac
+++ b/configure.ac
@@ -266,7 +266,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <openssl/evp.h>
 #include <openssl/engine.h>
 #include <openssl/conf.h>
-/* routine to load gost (from sldns) */
+/* routine to load gost (from gldns) */
 int load_gost_id(void)
 {
 	static int gost_id = 0;
@@ -605,60 +605,6 @@ AC_SUBST([CHECK_GETDNS])
 AC_SUBST([CHECK_LIBS])
 AC_SUBST([CHECK_CFLAGS])
 # end libraries needed for libcheck
-
-# find libldns
-LIBS="$initial_LIBS"
-
-LDNS_LIBS=""
-LDNS_CFLAGS=""
-LDNS_LDFLAGS=""
-NOLIBLDNS=""
-
-AC_ARG_WITH(libldns, AS_HELP_STRING([--with-libldns=pathname],
-	[path to libldns (default: search /usr/local ..)]),
-	[], [withval="yes"])
-if test x_$withval = x_yes; then
-	for dir in /usr/local /opt/local /usr/pkg /usr/sfw; do
-		if test -f "$dir/include/ldns/ldns.h"; then
-			LDNS_CFLAGS="-I$dir/include"
-			LDNS_LDFLAGS="-L$dir/lib"
-			CFLAGS="$CFLAGS $LDNS_CFLAGS"
-			LDFLAGS="$LDFLAGS $LDNS_LDFLAGS"
-			AC_MSG_NOTICE([Found libldns in $dir])
-			break
-		fi
-	done
-else
-	if test x_$withval != x_no; then
-		LDNS_CFLAGS="-I$withval/include"
-		LDNS_LDFLAGS="-L$withval/lib"
-		CFLAGS="$CFLAGS $LDNS_CFLAGS"
-		LDFLAGS="$LDFLAGS $LDNS_LDFLAGS"
-	else
-		NOLIBLDNS="nolibldns"
-		AC_MSG_WARN([libldns not found or usable; unit tests will not be compiled and run])
-	fi
-fi
-if test x$NOLIBLDNS = x
-then
-AC_CHECK_LIB([ldns], [ldns_dname_new_frm_str], [
-LDNS_LIBS="-lldns"
-AC_DEFINE_UNQUOTED(HAVE_LIBLDNS, [1], [Have libldns])
-], [
-NOLIBLDNS="nolibldns"
-AC_MSG_WARN([libldns not found or usable; unit tests will not be compiled and run])
-])
-fi
-
-AC_SUBST([LDNS_LIBS])
-AC_SUBST([LDNS_CFLAGS])
-AC_SUBST([LDNS_LDFLAGS])
-AC_SUBST([NOLIBLDNS])
-
-LIBS="$getdns_LIBS"
-CFLAGS="$getdns_CFLAGS"
-LDFLAGS="$getdns_LDFLAGS"
-
 
 #-------------------- libevent extension
 AC_ARG_WITH([libevent],

--- a/src/getdns/getdns_extra.h.in
+++ b/src/getdns/getdns_extra.h.in
@@ -611,7 +611,7 @@ getdns_rr_dict2str_scan(
 /**
  * Convert the string representation of the resource record to rr_dict format.
  *
- * @param  str        String representation of the resource record.
+ * @param  str         String representation of the resource record.
  * @return rr_dict     The result getdns dict representation of the resource record
  * @param  origin      Default suffix for not fully qualified domain names
  * @param  default_ttl Default ttl
@@ -625,7 +625,7 @@ getdns_str2rr_dict(
 /**
  * Read the zonefile and convert to a list of rr_dict's.
  *
- * @param  fp          String representation of the resource record.
+ * @param  fp          An opened FILE pointer on the zone file.
  * @return rr_list     The result list of rr_dicts representing the zone file.
  * @param  origin      Default suffix for not fully qualified domain names
  * @param  default_ttl Default ttl
@@ -635,6 +635,149 @@ getdns_return_t
 getdns_fp2rr_list(
     FILE *in, getdns_list **rr_list,
     const char *origin, uint32_t default_ttl);
+
+/**
+ * Convert DNS message dict to wireformat representation.
+ *
+ * @param  msg_dict The getdns dict representation of a DNS message
+ * @return wire     A newly allocated buffer which will contain the wireformat.
+ * @return wire_sz  The size of the allocated buffer and the wireformat.
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ */
+getdns_return_t
+getdns_msg_dict2wire(
+    const getdns_dict *msg_dict, uint8_t **wire, size_t *wire_sz);
+
+/**
+ * Convert DNS message dict to wireformat representation.
+ *
+ * @param  msg_dict The getdns dict representation of a DNS message 
+ * @param  wire     The buffer in which the wireformat will be written
+ * @param  wire_sz  On input the size of the wire buffer,
+ *                  On output the amount of wireformat needed for the
+ *                  wireformat representation of the DNS message;
+ *                  even if it did not fit.
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ * GETDNS_RETURN_NEED_MORE_SPACE will be returned when the buffer was too
+ * small.  wire_sz will be set to the needed buffer space then.
+ */
+getdns_return_t
+getdns_msg_dict2wire_buf(
+    const getdns_dict *msg_dict, uint8_t *wire, size_t *wire_sz);
+
+/**
+ * Convert DNS message dict to wireformat representation.
+ *
+ * @param  msg_dict The getdns dict representation of the DNS message
+ * @param  wire     A pointer to the buffer pointer in which the wireformat 
+ *                  will be written.
+ *                  On output the buffer pointer will have moved along
+ *                  the buffer and point right after the just written RR.
+ * @param  wire_sz  On input the size of the wire buffer,
+ *                  On output the amount of wireformat needed for the
+ *                  wireformat will have been substracted from wire_sz.
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ * GETDNS_RETURN_NEED_MORE_SPACE will be returned when the buffer was too
+ * small.  The function will pretend that it had written beyond the end
+ * of the buffer, and wire will point past the buffer and wire_sz will
+ * contain a negative value.
+ */
+getdns_return_t
+getdns_msg_dict2wire_scan(
+    const getdns_dict *msg_dict, uint8_t **wire, int *wire_sz);
+
+
+/**
+ * Convert wireformat DNS message in a getdns msg_dict representation.
+ *
+ * @param  wire     Buffer containing the wireformat rr
+ * @param  wire_sz  Size of the wire buffer
+ * @return msg_dict The returned DNS message
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ */
+getdns_return_t
+getdns_wire2msg_dict(
+    const uint8_t *wire, size_t wire_sz, getdns_dict **msg_dict);
+
+/**
+ * Convert wireformat DNS message in a getdns msg_dict representation.
+ *
+ * @param  wire     Buffer containing the wireformat rr
+ * @param  wire_sz  On input the size of the wire buffer
+ *                  On output the length of the wireformat rr.
+ * @return msg_dict The returned DNS message
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ */
+getdns_return_t
+getdns_wire2msg_dict_buf(
+    const uint8_t *wire, size_t *wire_sz, getdns_dict **msg_dict);
+
+/**
+ * Convert wireformat DNS message in a getdns msg_dic representation.
+ *
+ * @param  wire     A pointer to the pointer of the wireformat buffer.
+ *                  On return this pointer is moved to after first read
+ *                  in resource record.
+ * @param  wire_sz  On input the size of the wire buffer
+ *                  On output the size is decreased with the length
+ *                  of the wireformat DNS message.
+ * @return msg_dict The returned DNS message
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ */
+getdns_return_t
+getdns_wire2msg_dict_scan(
+    const uint8_t **wire, size_t *wire_sz, getdns_dict **msg_dict);
+
+
+/**
+ * Convert msg_dict to the string representation of the DNS message.
+ *
+ * @param  msg_dict The getdns dict representation of the DNS message
+ * @return str      A newly allocated string representation of the rr
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ */
+getdns_return_t
+getdns_msg_dict2str(
+    const getdns_dict *msg_dict, char **str);
+
+/**
+ * Convert msg_dict to the string representation of the DNS message.
+ *
+ * @param  msg_dict The getdns dict representation of the resource record
+ * @param  str      The buffer in which the string will be written
+ * @param  str_len  On input the size of the text buffer,
+ *                  On output the amount of characters needed to write
+ *                  the string representation of the rr.  Even if it does
+ *                  not fit.
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ * GETDNS_RETURN_NEED_MORE_SPACE will be returned when the buffer was too
+ * small.  str_len will be set to the needed buffer space then.
+ */
+getdns_return_t
+getdns_msg_dict2str_buf(
+    const getdns_dict *msg_dict, char *str, size_t *str_len);
+
+/**
+ * Convert msg_dict to the string representation of the resource record.
+ *
+ * @param  msg_dict The getdns dict representation of the resource record
+ * @param  str      A pointer to the buffer pointer in which the string 
+ *                  will be written.
+ *                  On output the buffer pointer will have moved along
+ *                  the buffer and point right after the just written RR.
+ * @param  str_len  On input the size of the str buffer,
+ *                  On output the number of characters needed for the
+ *                  string will have been substracted from strlen.
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ * GETDNS_RETURN_NEED_MORE_SPACE will be returned when the buffer was too
+ * small.  The function will pretend that it had written beyond the end
+ * of the buffer, and str will point past the buffer and str_len will
+ * contain a negative value.
+ */
+getdns_return_t
+getdns_msg_dict2str_scan(
+    const getdns_dict *msg_dict, char **str, int *str_len);
+
 
 /**
  * Validate replies or resource records.
@@ -669,6 +812,8 @@ getdns_validate_dnssec2(getdns_list *to_validate,
     getdns_list *support_records,
     getdns_list *trust_anchors,
     time_t validation_time, uint32_t skew);
+
+
 
 #ifdef __cplusplus
 }

--- a/src/libgetdns.symbols
+++ b/src/libgetdns.symbols
@@ -108,6 +108,12 @@ getdns_list_set_bindata
 getdns_list_set_dict
 getdns_list_set_int
 getdns_list_set_list
+getdns_msg_dict2str
+getdns_msg_dict2str_buf
+getdns_msg_dict2str_scan
+getdns_msg_dict2wire
+getdns_msg_dict2wire_buf
+getdns_msg_dict2wire_scan
 getdns_pretty_print_dict
 getdns_pretty_print_list
 getdns_pretty_snprint_dict
@@ -131,6 +137,9 @@ getdns_str2rr_dict
 getdns_strerror
 getdns_validate_dnssec
 getdns_validate_dnssec2
+getdns_wire2msg_dict
+getdns_wire2msg_dict_buf
+getdns_wire2msg_dict_scan
 getdns_wire2rr_dict
 getdns_wire2rr_dict_buf
 getdns_wire2rr_dict_scan

--- a/src/test/Makefile.in
+++ b/src/test/Makefile.in
@@ -43,7 +43,6 @@ have_libevent = @have_libevent@
 have_libuv = @have_libuv@
 have_libev = @have_libev@
 NOLIBCHECK = @NOLIBCHECK@
-NOLIBLDNS = @NOLIBLDNS@
 
 EXTENSION_LIBEVENT_EXT_LIBS=@EXTENSION_LIBEVENT_EXT_LIBS@
 EXTENSION_LIBEVENT_LDFLAGS=@EXTENSION_LIBEVENT_LDFLAGS@
@@ -63,9 +62,6 @@ LDFLAGS=-L.. @LDFLAGS@
 LDLIBS=../libgetdns.la @LIBS@
 CHECK_LIBS=@CHECK_LIBS@
 CHECK_CFLAGS=@CHECK_CFLAGS@
-LDNS_LIBS=@LDNS_LIBS@
-LDNS_CFLAGS=@LDNS_CFLAGS@
-LDNS_LDFLAGS=@LDNS_LDFLAGS@
 
 CHECK_OBJS=check_getdns_common.lo check_getdns_context_set_timeout.lo \
 	check_getdns.lo check_getdns_transport.lo
@@ -93,7 +89,7 @@ default: all
 all: $(PROGRAMS)
 
 $(ALL_OBJS):
-	$(LIBTOOL) --quiet --tag=CC --mode=compile $(CC) $(CFLAGS) $(LDNS_CFLAGS) -c $(srcdir)/$(@:.lo=.c) -o $@
+	$(LIBTOOL) --quiet --tag=CC --mode=compile $(CC) $(CFLAGS) -c $(srcdir)/$(@:.lo=.c) -o $@
 
 $(NON_C99_OBJS):
 	$(LIBTOOL) --quiet --tag=CC --mode=compile $(CC) $(CFLAGS) -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600 -c $(srcdir)/$(@:.lo=.c) -o $@
@@ -117,16 +113,16 @@ check_getdns_common: check_getdns_common.lo
 	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) $(LDFLAGS) $(LDLIBS) -o $@ check_getdns_common.lo
 
 check_getdns: check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_selectloop.lo
-	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) $(LDNS_CFLAGS) $(LDNS_LDFLAGS) $(LDNS_LIBS) -o $@ check_getdns.lo check_getdns_common.lo  check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_selectloop.lo
+	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) -o $@ check_getdns.lo check_getdns_common.lo  check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_selectloop.lo
 
 check_getdns_event: check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libevent.lo ../libgetdns_ext_event.la
-	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libevent.lo $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) $(LDNS_CFLAGS) $(LDNS_LDFLAGS) $(LDNS_LIBS) ../libgetdns_ext_event.la $(EXTENSION_LIBEVENT_LDFLAGS) $(EXTENSION_LIBEVENT_EXT_LIBS)
+	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libevent.lo $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) ../libgetdns_ext_event.la $(EXTENSION_LIBEVENT_LDFLAGS) $(EXTENSION_LIBEVENT_EXT_LIBS)
 
 check_getdns_uv: check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libuv.lo ../libgetdns_ext_uv.la
-	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libuv.lo $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) $(LDNS_CFLAGS) $(LDNS_LDFLAGS) $(LDNS_LIBS) ../libgetdns_ext_uv.la $(EXTENSION_LIBUV_LDFLAGS) $(EXTENSION_LIBUV_EXT_LIBS)
+	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libuv.lo $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) ../libgetdns_ext_uv.la $(EXTENSION_LIBUV_LDFLAGS) $(EXTENSION_LIBUV_EXT_LIBS)
 
 check_getdns_ev: check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libev.lo ../libgetdns_ext_ev.la
-	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libev.lo $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) $(LDNS_CFLAGS) $(LDNS_LDFLAGS) $(LDNS_LIBS) ../libgetdns_ext_ev.la $(EXTENSION_LIBEV_LDFLAGS) $(EXTENSION_LIBEV_EXT_LIBS)
+	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ check_getdns.lo check_getdns_common.lo check_getdns_context_set_timeout.lo check_getdns_transport.lo check_getdns_libev.lo $(LDFLAGS) $(LDLIBS) $(CHECK_CFLAGS) $(CHECK_LIBS) ../libgetdns_ext_ev.la $(EXTENSION_LIBEV_LDFLAGS) $(EXTENSION_LIBEV_EXT_LIBS)
 
 getdns_query: getdns_query.lo
 	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ getdns_query.lo $(LDFLAGS) $(LDLIBS)
@@ -155,16 +151,7 @@ nolibcheck:
 	@echo "***"
 	@false
 
-nolibldns:
-	@echo "***"
-	@echo "*** Cannot run unit tests, because they could not be compiled,"
-	@echo "*** because libldns was not found or usable at configure time."
-	@echo "*** To compile and run unit tests make sure libldns is available"
-	@echo "*** and usable during configuration"
-	@echo "***"
-	@false
-
-test:	$(NOLIBCHECK) $(NOLIBLDNS) all
+test:	$(NOLIBCHECK) all
 	(cd $(srcdir)/../.. && find . -type f -executable -and \( -name "*.[ch]" -or -name "*.html" -or -name "*.in" -or -name "*.good" -or -name "*.ac" \) | awk 'BEGIN{e=0}{print("ERROR! Executable bit found on", $$0);e=1}END{exit(e)}')
 	./$(CHECK_GETDNS)
 	if test $(have_libevent) = 1 ; then ./$(CHECK_EVENT_PROG) ; fi

--- a/src/test/tpkg/tpkg
+++ b/src/test/tpkg/tpkg
@@ -299,9 +299,9 @@ function report() {
                 pper=0
                 uper=0
         else
-                fper=`echo -e "scale=4\n$failed/$total*100" | bc | sed 's/00$//'`
-                pper=`echo -e "scale=4\n$passed/$total*100" | bc | sed 's/00$//'`
-                uper=`echo -e "scale=4\n$unknown/$total*100" | bc | sed 's/00$//'`
+		fper=`awk -vN=$failed -vT=$total 'BEGIN{printf("%.0f",(N/T*100))}'`
+		pper=`awk -vN=$passed -vT=$total 'BEGIN{printf("%.0f",(N/T*100))}'`
+		uper=`awk -vN=$unknown -vT=$total 'BEGIN{printf("%.0f",(N/T*100))}'`
         fi
         echo
         echo -e "$tp: $passed ($pper %)\t$tf: $failed ($fper %)\t$tu: $unknown ($uper %)"


### PR DESCRIPTION
Conversion function for complete DNS messages:
  - to and from wireformat
  - to string
This enabled removing the ldns dependency of the unit tests too