### PR TITLE
A dnssec_return_all_statuses extension

### DIFF
--- a/src/general.c
+++ b/src/general.c
@@ -245,7 +245,8 @@ _getdns_check_dns_req_complete(getdns_dns_req *dns_req)
 #ifdef STUB_NATIVE_DNSSEC
 	    || (dns_req->context->resolution_type == GETDNS_RESOLUTION_STUB
 	        && (dns_req->dnssec_return_status ||
-	            dns_req->dnssec_return_only_secure
+	            dns_req->dnssec_return_only_secure ||
+	            dns_req->dnssec_return_all_statuses
 	           ))
 #endif
 	    )
@@ -302,6 +303,7 @@ _getdns_submit_netreq(getdns_network_req *netreq)
 	if ( dns_req->context->resolution_type == GETDNS_RESOLUTION_RECURSING
 	    || dns_req->dnssec_return_status
 	    || dns_req->dnssec_return_only_secure
+	    || dns_req->dnssec_return_all_statuses
 	    || dns_req->dnssec_return_validation_chain) {
 #endif
 		/* schedule the timeout */
@@ -362,6 +364,7 @@ validate_extensions(struct getdns_dict * extensions)
 	static getdns_extension_format extformats[] = {
 		{"add_opt_parameters"            , t_dict, 1},
 		{"add_warning_for_bad_dns"       , t_int , 1},
+		{"dnssec_return_all_statuses"    , t_int , 1},
 		{"dnssec_return_only_secure"     , t_int , 1},
 		{"dnssec_return_status"          , t_int , 1},
 		{"dnssec_return_validation_chain", t_int , 1},

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -639,6 +639,8 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	    || is_extension_set(extensions, "dnssec_return_status");
 	int dnssec_return_only_secure
 	    =  is_extension_set(extensions, "dnssec_return_only_secure");
+	int dnssec_return_all_statuses
+	    =  is_extension_set(extensions, "dnssec_return_all_statuses");
 	int dnssec_return_validation_chain
 	    =  is_extension_set(extensions, "dnssec_return_validation_chain");
 	int edns_cookies
@@ -653,7 +655,8 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 #endif
 
 	int dnssec_extension_set = dnssec_return_status
-	    || dnssec_return_only_secure || dnssec_return_validation_chain
+	    || dnssec_return_only_secure || dnssec_return_all_statuses
+	    || dnssec_return_validation_chain
 	    || (extensions == dnssec_ok_checking_disabled)
 	    || (extensions == dnssec_ok_checking_disabled_roadblock_avoidance)
 	    || (extensions == dnssec_ok_checking_disabled_avoid_roadblocks)
@@ -850,6 +853,7 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	                    ((uint64_t)arc4random());
 	result->dnssec_return_status           = dnssec_return_status;
 	result->dnssec_return_only_secure      = dnssec_return_only_secure;
+	result->dnssec_return_all_statuses     = dnssec_return_all_statuses;
 	result->dnssec_return_validation_chain = dnssec_return_validation_chain;
 	result->edns_cookies                   = edns_cookies;
 #ifdef DNSSEC_ROADBLOCK_AVOIDANCE

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -471,6 +471,7 @@ print_usage(FILE *out, const char *progname)
 	fprintf(out, "\t+add_warning_for_bad_dns\n");
 	fprintf(out, "\t+dnssec_return_status\n");
 	fprintf(out, "\t+dnssec_return_only_secure\n");
+	fprintf(out, "\t+dnssec_return_all_statuses\n");
 	fprintf(out, "\t+dnssec_return_validation_chain\n");
 #ifdef DNSSEC_ROADBLOCK_AVOIDANCE
 	fprintf(out, "\t+dnssec_roadblock_avoidance\n");

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -286,6 +286,7 @@ typedef struct getdns_dns_req {
 	/* request extensions */
 	int dnssec_return_status;
 	int dnssec_return_only_secure;
+	int dnssec_return_all_statuses;
 	int dnssec_return_validation_chain;
 #ifdef DNSSEC_ROADBLOCK_AVOIDANCE
 	int dnssec_roadblock_avoidance;

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -862,7 +862,8 @@ _getdns_create_getdns_response(getdns_dns_req *completed_request)
 		return NULL;
 
 	dnssec_return_status = completed_request->dnssec_return_status ||
-	                       completed_request->dnssec_return_only_secure
+	                       completed_request->dnssec_return_only_secure ||
+	                       completed_request->dnssec_return_all_statuses
 #ifdef DNSSEC_ROADBLOCK_AVOIDANCE
 	                    || completed_request->dnssec_roadblock_avoidance
 #endif
@@ -907,7 +908,8 @@ _getdns_create_getdns_response(getdns_dns_req *completed_request)
 			nbogus++;
 
 
-		if (! completed_request->dnssec_return_validation_chain) {
+		if (! completed_request->dnssec_return_all_statuses &&
+		    ! completed_request->dnssec_return_validation_chain) {
 			if (dnssec_return_status &&
 			    netreq->dnssec_status == GETDNS_DNSSEC_BOGUS)
 				continue;


### PR DESCRIPTION
that returns all all dnssec replies regardless their status.
When used on its own or in combination with just dnssec_return_status,
     it will return BOGUS replies, but those replies will have "dnssec_status": GETDNS_DNSSEC_BOGUS
     The response dict "status" will be GETDNS_RESPSTATUS_GOOD then.
When used on in combination with dnssec_return_only_secure,
     it will return BOGUS and INSECURE replies (reflected in their "dnssec_status")
     The response dict "status" can be any of the status that the dnssec_return_only_secure extenstion returns,
     so either GETDNS_RESPSTATUS_GOOD when at least one reply was secure,
     GETDNS_RESPSTATUS_NO_SECURE_ANSWERS when all replies were insecure,
     or GETDNS_RESPSTATUS_ALL_BOGUS_ANSWERS when all replies were bogus.