### PR TITLE
No more side effects with synchronous calls

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -140,6 +140,23 @@ typedef struct getdns_upstream {
 	getdns_network_req      *write_queue_last;
 	_getdns_rbtree_t          netreq_by_query_id;
 
+	/* When requests have been scheduled asynchronously on an upstream
+	 * that is kept open, and a synchronous call is then done with the
+	 * upstream before all scheduled requests have been answered, answers
+	 * for the asynchronous requests may be received on the open upstream.
+	 * Those cannot be processed immediately, because then asynchronous
+	 * callbacks will be fired as a side-effect.
+	 *
+	 * finished_dnsreqs is a list of dnsreqs for which answers have been
+	 * received during a synchronous request.  They will be processed
+	 * when the asynchronous eventloop is run.  For this the finished_event
+	 * will be scheduled to the registered asynchronous event loop with a
+	 * timeout of 1, so it will fire immediately (but not while scheduling)
+	 * when the asynchronous eventloop is run.
+	 */
+	getdns_dns_req          *finished_dnsreqs;
+	getdns_eventloop_event   finished_event;
+
 	/* EDNS cookies */
 	uint32_t secret;
 	uint8_t  client_cookie[8];

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -886,6 +886,8 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	if (result->upstreams)
 		result->upstreams->referenced++;
 
+	result->finished_next = NULL;
+
 	network_req_init(result->netreqs[0], result,
 	    request_type, dnssec_extension_set, with_opt,
 	    edns_maximum_udp_payload_size,

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -323,6 +323,13 @@ typedef struct getdns_dns_req {
 	/* Stuff for stub resolving */
 	struct getdns_upstreams *upstreams;
 
+	/* Linked list pointer for dns requests, for which answers are received
+	 * from open connections as aside-effect of doing a synchronous call.
+	 * See also the type definition of getdns_upstream in context.h for a
+	 * more elaborate description.
+	 */
+	struct getdns_dns_req *finished_next;
+
 	/* network requests for this dns request.
 	 * The array is terminated with NULL.
 	 *


### PR DESCRIPTION
No more side effects with synchronous calls when using upstreams that keep connections open.
This will eliminate all side effects with synchronous calls when linked against libunbound newer than 1.5.8 (which has the unbound event API available).