### PR TITLE
Add a pkg-config file for the getdns_ext_event library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ m4/lt~obsolete.m4
 src/config.h.in
 build/
 getdns.pc
+getdns_ext_event.pc

--- a/Makefile.in
+++ b/Makefile.in
@@ -49,7 +49,7 @@ all : default @GETDNS_QUERY@
 default:
 	cd src && $(MAKE) $@
 
-install: all getdns.pc @INSTALL_GETDNS_QUERY@
+install: all getdns.pc getdns_ext_event.pc @INSTALL_GETDNS_QUERY@
 	$(INSTALL) -m 755 -d $(DESTDIR)$(docdir)
 	$(INSTALL) -m 644 $(srcdir)/AUTHORS $(DESTDIR)$(docdir)
 	$(INSTALL) -m 644 $(srcdir)/ChangeLog $(DESTDIR)$(docdir)
@@ -60,6 +60,7 @@ install: all getdns.pc @INSTALL_GETDNS_QUERY@
 	$(INSTALL) -m 644 $(srcdir)/README.md $(DESTDIR)$(docdir)
 	$(INSTALL) -m 755 -d $(DESTDIR)$(libdir)/pkgconfig
 	$(INSTALL) -m 644 getdns.pc $(DESTDIR)$(libdir)/pkgconfig
+	$(INSTALL) -m 644 getdns_ext_event.pc $(DESTDIR)$(libdir)/pkgconfig
 	$(INSTALL) -m 755 -d $(DESTDIR)$(docdir)/spec
 	$(INSTALL) -m 644 $(srcdir)/spec/index.html $(DESTDIR)$(docdir)/spec
 	$(INSTALL) -m 644 $(srcdir)/spec/getdns*tgz $(DESTDIR)$(docdir)/spec || true
@@ -130,7 +131,7 @@ distclean:
 	cd spec/example && $(MAKE) $@
 	rmdir spec/example 2>/dev/null || true
 	rmdir spec 2>/dev/null || true
-	rm -f config.log config.status Makefile libtool getdns.pc
+	rm -f config.log config.status Makefile libtool getdns.pc getdns_ext_event.pc
 	rm -fR autom4te.cache
 	rm -f m4/libtool.m4
 	rm -f m4/lt~obsolete.m4
@@ -195,6 +196,7 @@ $(distdir):
 	cp $(srcdir)/config.sub $(distdir)
 	cp $(srcdir)/config.guess $(distdir)
 	cp $(srcdir)/getdns.pc.in $(distdir)
+	cp $(srcdir)/getdns_ext_event.pc.in $(distdir)
 	cp libtool $(distdir)
 	cp $(srcdir)/ltmain.sh $(distdir)
 	cp $(srcdir)/m4/*.m4 $(distdir)/m4
@@ -238,6 +240,9 @@ distcheck: $(distdir).tar.gz
 	@echo "*** Package $(distdir).tar.gz is ready for distribution"
 
 getdns.pc: $(srcdir)/getdns.pc.in
+	./config.status $@
+
+getdns_ext_event.pc: $(srcdir)/getdns_ext_event.pc.in
 	./config.status $@
 
 Makefile: $(srcdir)/Makefile.in config.status

--- a/configure.ac
+++ b/configure.ac
@@ -884,7 +884,7 @@ AC_SUBST(GETDNS_QUERY)
 AC_SUBST(INSTALL_GETDNS_QUERY)
 AC_SUBST(UNINSTALL_GETDNS_QUERY)
 
-AC_CONFIG_FILES([Makefile src/Makefile src/version.c src/getdns/getdns.h src/getdns/getdns_extra.h spec/example/Makefile src/test/Makefile doc/Makefile getdns.pc])
+AC_CONFIG_FILES([Makefile src/Makefile src/version.c src/getdns/getdns.h src/getdns/getdns_extra.h spec/example/Makefile src/test/Makefile doc/Makefile getdns.pc getdns_ext_event.pc])
 if [ test -n "$DOXYGEN" ]
     then AC_CONFIG_FILES([src/Doxyfile])
 fi

--- a/getdns_ext_event.pc.in
+++ b/getdns_ext_event.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: getdns_ext_event 
+Version: @GETDNS_VERSION@
+Description: A modern asynchronous DNS library
+
+Libs: -L${libdir} -lgetdns_ext_event
+Cflags: -I${includedir}


### PR DESCRIPTION
This can be used in an application configure.ac file as follows:
PKG_CHECK_MODULES([GETDNS], [getdns getdns_ext_event])
