### PR TITLE
Features/canonical dnssec chain

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -236,7 +236,7 @@ context.lo context.o: $(srcdir)/context.c \
  getdns/getdns_extra.h \
  $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/extension/default_eventloop.h $(srcdir)/ub_loop.h \
  $(srcdir)/util-internal.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h \
- $(srcdir)/dnssec.h $(srcdir)/stub.h $(srcdir)/list.h $(srcdir)/dict.h $(srcdir)/pubkey-pinning.h
+ $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h $(srcdir)/stub.h $(srcdir)/list.h $(srcdir)/dict.h $(srcdir)/pubkey-pinning.h
 convert.lo convert.o: $(srcdir)/convert.c \
  config.h \
  getdns/getdns.h \
@@ -260,8 +260,9 @@ dnssec.lo dnssec.o: $(srcdir)/dnssec.c \
  getdns/getdns_extra.h \
  $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/extension/default_eventloop.h $(srcdir)/ub_loop.h \
  $(srcdir)/util-internal.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h \
- $(srcdir)/dnssec.h $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/wire2str.h $(srcdir)/gldns/keyraw.h \
- $(srcdir)/gldns/parseutil.h $(srcdir)/general.h $(srcdir)/dict.h $(srcdir)/list.h $(srcdir)/util/val_secalgo.h
+ $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/wire2str.h \
+ $(srcdir)/gldns/keyraw.h $(srcdir)/gldns/parseutil.h $(srcdir)/general.h $(srcdir)/dict.h $(srcdir)/list.h \
+ $(srcdir)/util/val_secalgo.h
 general.lo general.o: $(srcdir)/general.c \
  config.h $(srcdir)/general.h \
  getdns/getdns.h \
@@ -269,7 +270,7 @@ general.lo general.o: $(srcdir)/general.c \
  getdns/getdns_extra.h \
  $(srcdir)/util/rbtree.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/gldns/wire2str.h $(srcdir)/context.h \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/util-internal.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h \
- $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h $(srcdir)/dnssec.h $(srcdir)/stub.h $(srcdir)/dict.h
+ $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h $(srcdir)/stub.h $(srcdir)/dict.h
 list.lo list.o: $(srcdir)/list.c $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
@@ -319,7 +320,7 @@ sync.lo sync.o: $(srcdir)/sync.c \
  getdns/getdns_extra.h \
  $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/extension/default_eventloop.h $(srcdir)/ub_loop.h \
  $(srcdir)/debug.h $(srcdir)/general.h $(srcdir)/util-internal.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
- $(srcdir)/gldns/pkthdr.h $(srcdir)/dnssec.h $(srcdir)/stub.h $(srcdir)/gldns/wire2str.h
+ $(srcdir)/gldns/pkthdr.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h $(srcdir)/stub.h $(srcdir)/gldns/wire2str.h
 ub_loop.lo ub_loop.o: $(srcdir)/ub_loop.c $(srcdir)/ub_loop.h \
  config.h \
  getdns/getdns.h \
@@ -332,7 +333,7 @@ util-internal.lo util-internal.o: $(srcdir)/util-internal.c \
  getdns/getdns_extra.h \
  $(srcdir)/list.h $(srcdir)/util-internal.h $(srcdir)/context.h $(srcdir)/extension/default_eventloop.h $(srcdir)/ub_loop.h \
  $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h \
- $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h
+ $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h
 gbuffer.lo gbuffer.o: $(srcdir)/gldns/gbuffer.c \
  config.h \
  $(srcdir)/gldns/gbuffer.h

--- a/src/dict.c
+++ b/src/dict.c
@@ -602,6 +602,24 @@ getdns_dict_set_list(
 
 /*---------------------------------------- getdns_dict_set_bindata */
 getdns_return_t
+_getdns_dict_set_this_bindata(
+    getdns_dict *dict, const char *name, getdns_bindata *bindata)
+{
+	getdns_item    *item;
+	getdns_return_t r;
+
+	if (!dict || !name || !bindata)
+		return GETDNS_RETURN_INVALID_PARAMETER;
+
+	if ((r = _getdns_dict_find_and_add(dict, name, &item)))
+		return r;
+
+	item->dtype = t_bindata;
+	item->data.bindata = bindata;
+	return GETDNS_RETURN_GOOD;
+}
+
+getdns_return_t
 _getdns_dict_set_const_bindata(
     getdns_dict *dict, const char *name, size_t size, const void *data)
 {

--- a/src/dnssec.h
+++ b/src/dnssec.h
@@ -41,12 +41,28 @@
 #include "getdns/getdns.h"
 #include "config.h"
 #include "gldns/gbuffer.h"
+#include "gldns/rrdef.h"
 #include "types-internal.h"
 
 /* Do some additional requests to fetch the complete validation chain */
 void _getdns_get_validation_chain(getdns_dns_req *dns_req);
 
 uint16_t _getdns_parse_ta_file(time_t *ta_mtime, gldns_buffer *gbuf);
+
+inline static int _dnssec_rdata_to_canonicalize(uint16_t rr_type)
+{
+	return rr_type == GLDNS_RR_TYPE_NS    || rr_type == GLDNS_RR_TYPE_MD
+	    || rr_type == GLDNS_RR_TYPE_MF    || rr_type == GLDNS_RR_TYPE_CNAME
+	    || rr_type == GLDNS_RR_TYPE_SOA   || rr_type == GLDNS_RR_TYPE_MB
+	    || rr_type == GLDNS_RR_TYPE_MG    || rr_type == GLDNS_RR_TYPE_MR
+	    || rr_type == GLDNS_RR_TYPE_PTR   || rr_type == GLDNS_RR_TYPE_MINFO
+	    || rr_type == GLDNS_RR_TYPE_MX    || rr_type == GLDNS_RR_TYPE_RP
+	    || rr_type == GLDNS_RR_TYPE_AFSDB || rr_type == GLDNS_RR_TYPE_RT
+	    || rr_type == GLDNS_RR_TYPE_SIG   || rr_type == GLDNS_RR_TYPE_PX
+	    || rr_type == GLDNS_RR_TYPE_NXT   || rr_type == GLDNS_RR_TYPE_NAPTR
+	    || rr_type == GLDNS_RR_TYPE_KX    || rr_type == GLDNS_RR_TYPE_SRV
+	    || rr_type == GLDNS_RR_TYPE_DNAME || rr_type == GLDNS_RR_TYPE_RRSIG;
+}
 
 #endif
 

--- a/src/general.c
+++ b/src/general.c
@@ -403,6 +403,7 @@ validate_extensions(struct getdns_dict * extensions)
 		{"add_opt_parameters"            , t_dict, 1},
 		{"add_warning_for_bad_dns"       , t_int , 1},
 		{"dnssec_return_all_statuses"    , t_int , 1},
+		{"dnssec_return_full_validation_chain", t_int , 1},
 		{"dnssec_return_only_secure"     , t_int , 1},
 		{"dnssec_return_status"          , t_int , 1},
 		{"dnssec_return_validation_chain", t_int , 1},

--- a/src/general.h
+++ b/src/general.h
@@ -42,9 +42,11 @@
 
 /* private inner helper used by sync and async */
 
+#define DNS_REQ_FINISHED -1
+
 void _getdns_call_user_callback(getdns_dns_req *, getdns_dict *);
 void _getdns_check_dns_req_complete(getdns_dns_req *dns_req);
-getdns_return_t _getdns_submit_netreq(getdns_network_req *netreq);
+int _getdns_submit_netreq(getdns_network_req *netreq);
 
 
 getdns_return_t

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -640,7 +640,8 @@ _getdns_dns_req_free(getdns_dns_req * req)
 		req->loop->vmt->clear(req->loop, &req->timeout);
 		req->timeout.timeout_cb = NULL;
 	}
-
+	if (req->freed)
+		*req->freed = 1;
 	GETDNS_FREE(req->my_mf, req);
 }
 
@@ -907,6 +908,8 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 		result->upstreams->referenced++;
 
 	result->finished_next = NULL;
+	result->freed = NULL;
+	result->validating = 0;
 
 	network_req_init(result->netreqs[0], result,
 	    request_type, dnssec_extension_set, with_opt,

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -658,6 +658,8 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	    =  is_extension_set(extensions, "dnssec_return_only_secure");
 	int dnssec_return_all_statuses
 	    =  is_extension_set(extensions, "dnssec_return_all_statuses");
+	int dnssec_return_full_validation_chain
+	    =  is_extension_set(extensions, "dnssec_return_full_validation_chain");
 	int dnssec_return_validation_chain
 	    =  is_extension_set(extensions, "dnssec_return_validation_chain");
 	int edns_cookies
@@ -674,6 +676,7 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	int dnssec_extension_set = dnssec_return_status
 	    || dnssec_return_only_secure || dnssec_return_all_statuses
 	    || dnssec_return_validation_chain
+	    || dnssec_return_full_validation_chain
 	    || (extensions == dnssec_ok_checking_disabled)
 	    || (extensions == dnssec_ok_checking_disabled_roadblock_avoidance)
 	    || (extensions == dnssec_ok_checking_disabled_avoid_roadblocks)
@@ -874,7 +877,10 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	result->dnssec_return_status           = dnssec_return_status;
 	result->dnssec_return_only_secure      = dnssec_return_only_secure;
 	result->dnssec_return_all_statuses     = dnssec_return_all_statuses;
-	result->dnssec_return_validation_chain = dnssec_return_validation_chain;
+	result->dnssec_return_full_validation_chain =
+		dnssec_return_full_validation_chain;
+	result->dnssec_return_validation_chain = dnssec_return_validation_chain
+	     || dnssec_return_full_validation_chain;
 	result->edns_cookies                   = edns_cookies;
 #ifdef DNSSEC_ROADBLOCK_AVOIDANCE
 	result->dnssec_roadblock_avoidance     = dnssec_roadblock_avoidance;

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -474,6 +474,7 @@ print_usage(FILE *out, const char *progname)
 	fprintf(out, "\t+dnssec_return_only_secure\n");
 	fprintf(out, "\t+dnssec_return_all_statuses\n");
 	fprintf(out, "\t+dnssec_return_validation_chain\n");
+	fprintf(out, "\t+dnssec_return_full_validation_chain\n");
 #ifdef DNSSEC_ROADBLOCK_AVOIDANCE
 	fprintf(out, "\t+dnssec_roadblock_avoidance\n");
 #endif

--- a/src/test/tpkg/125-valgrind-checks.tpkg/125-valgrind-checks.test
+++ b/src/test/tpkg/125-valgrind-checks.tpkg/125-valgrind-checks.test
@@ -6,8 +6,12 @@
 
 cat >queries <<EOT
 NS .
+localhost
+localhost.
+A localhost.
 -A getdnsapi.net
 qwerlkjhasdfpuiqwyerm.1234kjhrqwersv.com
+localhost.
 -G TXT bogus.nlnetlabs.nl
 -H 8.8.8.8
 -H 2a04:b900:0:100::37

--- a/src/test/tpkg/330-event-loops-unit-tests.tpkg/330-event-loops-unit-tests.test
+++ b/src/test/tpkg/330-event-loops-unit-tests.tpkg/330-event-loops-unit-tests.test
@@ -5,4 +5,10 @@
 [ -f .tpkg.var.test ] && source .tpkg.var.test
 
 cd "${BUILDDIR}/build-event-loops"
-make test
+if make test
+then
+	if grep ERROR "${BUILDDIR}/build-event-loops/src/test/*.log"
+	then
+		exit 1
+	fi
+fi

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -272,37 +272,39 @@ typedef struct getdns_dns_req {
 	uint8_t name[256];
 	size_t  name_len;
 
-	getdns_append_name_t append_name;
-	const uint8_t *suffix;
-	size_t  suffix_len;
-	int suffix_appended;
-
 	uint16_t request_class;
-
-	/* canceled flag */
-	int canceled;
 
 	/* context that owns the request */
 	struct getdns_context *context;
 
+	getdns_append_name_t append_name;
+	const uint8_t *suffix;
+	size_t  suffix_len;
+	int suffix_appended			: 1;
+
+	/* canceled flag */
+	int canceled				: 1;
+
 	/* request extensions */
-	int dnssec_return_status;
-	int dnssec_return_only_secure;
-	int dnssec_return_all_statuses;
-	int dnssec_return_validation_chain;
+	int dnssec_return_status		: 1;
+	int dnssec_return_only_secure		: 1;
+	int dnssec_return_all_statuses		: 1;
+	int dnssec_return_validation_chain	: 1;
+	int dnssec_return_full_validation_chain	: 1;
 #ifdef DNSSEC_ROADBLOCK_AVOIDANCE
-	int dnssec_roadblock_avoidance;
-	int avoid_dnssec_roadblocks;
+	int dnssec_roadblock_avoidance		: 1;
+	int avoid_dnssec_roadblocks		: 1;
 #endif
-	int edns_cookies;
-	int edns_client_subnet_private;
-	uint16_t tls_query_padding_blocksize;
-	int return_call_reporting;
-	int add_warning_for_bad_dns;
+	int edns_cookies			: 1;
+	int edns_client_subnet_private		: 1;
+	int return_call_reporting		: 1;
+	int add_warning_for_bad_dns		: 1;
 
 	/* Internally used by return_validation_chain */
-	int dnssec_ok_checking_disabled;
-	int is_sync_request;
+	int dnssec_ok_checking_disabled		: 1;
+	int is_sync_request			: 1;
+
+	uint16_t tls_query_padding_blocksize;
 
 	/* internally scheduled request */
 	internal_cb_t internal_cb;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -304,8 +304,6 @@ typedef struct getdns_dns_req {
 	int dnssec_ok_checking_disabled		: 1;
 	int is_sync_request			: 1;
 
-	uint16_t tls_query_padding_blocksize;
-
 	/* The validating and freed variables are used to make sure a single
 	 * code path is followed while processing a DNS request, even when
 	 * callbacks are already fired whilst the registering/scheduling call
@@ -314,8 +312,10 @@ typedef struct getdns_dns_req {
 	 * validating is touched by _getdns_get_validation_chain only and
 	 * freed      is touched by _getdns_submit_netreq only
 	 */
-	int validating;
+	int validating                          : 1;
 	int *freed;
+
+	uint16_t tls_query_padding_blocksize;
 
 	/* internally scheduled request */
 	internal_cb_t internal_cb;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -306,6 +306,17 @@ typedef struct getdns_dns_req {
 
 	uint16_t tls_query_padding_blocksize;
 
+	/* The validating and freed variables are used to make sure a single
+	 * code path is followed while processing a DNS request, even when
+	 * callbacks are already fired whilst the registering/scheduling call
+	 * (i.e. ub_resolve_event) has not returned yet.
+	 *
+	 * validating is touched by _getdns_get_validation_chain only and
+	 * freed      is touched by _getdns_submit_netreq only
+	 */
+	int validating;
+	int *freed;
+
 	/* internally scheduled request */
 	internal_cb_t internal_cb;
 

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -160,6 +160,9 @@ _getdns_rr_iter2rr_dict_canonical(
 	uint8_t ff_bytes[256];
 	uint16_t rr_type;
 	int canonicalize;
+	gldns_buffer gbuf;
+	getdns_bindata *bindata;
+	uint8_t *data;
 
 	assert(i);
 	if (!(rr_dict = _getdns_dict_create_with_mf(mf)))
@@ -402,14 +405,8 @@ _getdns_rr_iter2rr_dict_canonical(
 		goto rdata_error;
 
 	if (canonicalize && rdata_sz) {
-		fprintf(stderr, "XXXXXXXXXX: owner_len: %zu, rdata_len: %zu\n", owner_len, rdata_sz);
-
-		gldns_buffer gbuf;
-		getdns_bindata *bindata;
-		uint8_t *data = GETDNS_XMALLOC(
-		    *mf, uint8_t, owner_len + 10 + rdata_sz);
-
-		if (!data)
+		if (!(data = GETDNS_XMALLOC(
+		    *mf, uint8_t, owner_len + 10 + rdata_sz)))
 			return rr_dict;
 
 		gldns_buffer_init_frm_data(&gbuf, data, owner_len+10+rdata_sz);

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -51,6 +51,7 @@
 #include "gldns/str2wire.h"
 #include "gldns/gbuffer.h"
 #include "gldns/pkthdr.h"
+#include "dnssec.h"
 
 
 getdns_return_t
@@ -145,11 +146,12 @@ _getdns_sockaddr_to_dict(struct getdns_context *context, struct sockaddr_storage
 }
 
 getdns_dict *
-_getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
+_getdns_rr_iter2rr_dict_canonical(
+    struct mem_funcs *mf, _getdns_rr_iter *i, uint32_t *orig_ttl)
 {
 	getdns_dict *rr_dict, *rdata_dict;
 	const uint8_t *bin_data;
-	size_t bin_size;
+	size_t bin_size, owner_len = 0, rdata_sz;
 	uint32_t int_val = 0;
 	enum wf_data_type { wf_int, wf_bindata, wf_special } val_type;
 	_getdns_rdf_iter rdf_storage, *rdf;
@@ -157,6 +159,7 @@ _getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
 	getdns_dict *repeat_dict = NULL;
 	uint8_t ff_bytes[256];
 	uint16_t rr_type;
+	int canonicalize;
 
 	assert(i);
 	if (!(rr_dict = _getdns_dict_create_with_mf(mf)))
@@ -165,6 +168,12 @@ _getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
 	bin_data = _getdns_owner_if_or_as_decompressed(
 	    i, ff_bytes, &bin_size);
 
+	if (orig_ttl) {
+		if (bin_data != ff_bytes)
+			bin_data = memcpy(ff_bytes, bin_data, bin_size);
+		_dname_canonicalize2(ff_bytes);
+		owner_len = bin_size;
+	}
 	/* question */
 	if (_getdns_rr_iter_section(i) == GLDNS_SECTION_QUESTION) {
 
@@ -186,6 +195,9 @@ _getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
 
 		goto error;
 	}
+	canonicalize = orig_ttl && _dnssec_rdata_to_canonicalize(rr_type)
+	    && (i->rr_type + 12 <= i->nxt) /* To estimate rdata size */;
+
 	if (rr_type == GETDNS_RRTYPE_OPT) {
 		int_val = gldns_read_uint16(i->rr_type + 6);
 
@@ -210,7 +222,8 @@ _getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
 	    (uint32_t) gldns_read_uint16(i->rr_type + 2)) ||
 
 	    getdns_dict_set_int(rr_dict, "ttl",
-	    (uint32_t) gldns_read_uint32(i->rr_type + 4)) ||
+	    (  orig_ttl && rr_type != GETDNS_RRTYPE_RRSIG
+	    ? *orig_ttl : (uint32_t) gldns_read_uint32(i->rr_type + 4))) ||
 
 	    _getdns_dict_set_const_bindata(
 	    rr_dict, "name", bin_size, bin_data)) {
@@ -220,15 +233,21 @@ _getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
 	if (!(rdata_dict = _getdns_dict_create_with_mf(mf)))
 		return NULL;
 
-	if (i->rr_type + 10 <= i->nxt) {
+	if (i->rr_type + 10 <= i->nxt && !canonicalize) {
 		bin_size = i->nxt - (i->rr_type + 10);
 		bin_data = i->rr_type + 10;
 		if (_getdns_dict_set_const_bindata(
 		    rdata_dict, "rdata_raw", bin_size, bin_data))
 			goto rdata_error;
 	}
+	if (canonicalize)
+		rdata_sz = 0;
+
 	for ( rdf = _getdns_rdf_iter_init(&rdf_storage, i)
 	    ; rdf; rdf = _getdns_rdf_iter_next(rdf)) {
+		if (canonicalize && !(rdf->rdd_pos->type & GETDNS_RDF_DNAME)) {
+			rdata_sz += rdf->nxt - rdf->pos;
+		}
 		if (rdf->rdd_pos->type & GETDNS_RDF_INTEGER) {
 			val_type = wf_int;
 			switch (rdf->rdd_pos->type & GETDNS_RDF_FIXEDSZ) {
@@ -247,6 +266,12 @@ _getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
 			bin_data = _getdns_rdf_if_or_as_decompressed(
 			    rdf, ff_bytes, &bin_size);
 
+			if (canonicalize) {
+				if (bin_data != ff_bytes)
+					bin_data = memcpy(ff_bytes, bin_data, bin_size);
+				_dname_canonicalize2(ff_bytes);
+				rdata_sz += bin_size;
+			}
 		} else if (rdf->rdd_pos->type & GETDNS_RDF_BINDATA) {
 			val_type = wf_bindata;
 			if (rdf->rdd_pos->type & GETDNS_RDF_FIXEDSZ) {
@@ -376,6 +401,29 @@ _getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
 	if (_getdns_dict_set_this_dict(rr_dict, "rdata", rdata_dict))
 		goto rdata_error;
 
+	if (canonicalize && rdata_sz) {
+		fprintf(stderr, "XXXXXXXXXX: owner_len: %zu, rdata_len: %zu\n", owner_len, rdata_sz);
+
+		gldns_buffer gbuf;
+		getdns_bindata *bindata;
+		uint8_t *data = GETDNS_XMALLOC(
+		    *mf, uint8_t, owner_len + 10 + rdata_sz);
+
+		if (!data)
+			return rr_dict;
+
+		gldns_buffer_init_frm_data(&gbuf, data, owner_len+10+rdata_sz);
+		if (_getdns_rr_dict2wire(rr_dict, &gbuf) ||
+		    gldns_buffer_position(&gbuf) != owner_len + 10 + rdata_sz ||
+		    !(bindata = GETDNS_MALLOC(*mf, struct getdns_bindata))) {
+			GETDNS_FREE(*mf, data);
+			return rr_dict;
+		}
+		bindata->size = rdata_sz;
+		bindata->data = memmove(data, data + owner_len + 10, rdata_sz);
+		(void) _getdns_dict_set_this_bindata(rr_dict,
+		    "/rdata/rdata_raw", bindata);
+	}
 	return rr_dict;
 
 rdata_error:
@@ -385,6 +433,12 @@ rdata_error:
 error:
 	getdns_dict_destroy(rr_dict);
 	return NULL;
+}
+
+getdns_dict *
+_getdns_rr_iter2rr_dict(struct mem_funcs *mf, _getdns_rr_iter *i)
+{
+	return _getdns_rr_iter2rr_dict_canonical(mf, i, NULL);
 }
 
 int


### PR DESCRIPTION
The validation_chain returned will be in canonical form and order.
It also contains a new extension dnssec_return_full_validation_chain that will also return the records that were validated in the same chain in canonical form and order.  The output of the dnssec_return_full_validation_chain can be used almost directly in the tls dnssec chain extension.

Note that the canonical form and order can only be returned when the records could be validated.

Besides this, this pull request also contains many bugfixes for cases were callbacks are fired while the registering/scheduling call has not finished yet.