### PR TITLE
Devel/tpkg xtra configure params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     - libevent-dev
     - libev-dev
     - valgrind
+    - clang
 script:
   - mkdir tests
   - cd tests

--- a/Makefile.in
+++ b/Makefile.in
@@ -46,6 +46,9 @@ INSTALL = @INSTALL@
 
 all : default @GETDNS_QUERY@ 
 
+everything: default
+	cd src/test && $(MAKE)
+
 default:
 	cd src && $(MAKE) $@
 

--- a/src/context.c
+++ b/src/context.c
@@ -2473,7 +2473,8 @@ getdns_context_set_upstream_recursive_servers(struct getdns_context *context,
 	return GETDNS_RETURN_GOOD;
 
 invalid_parameter:
-	r = GETDNS_RETURN_INVALID_PARAMETER;
+	_getdns_upstreams_dereference(upstreams);
+	return GETDNS_RETURN_INVALID_PARAMETER;
 error:
 	_getdns_upstreams_dereference(upstreams);
 	return GETDNS_RETURN_CONTEXT_UPDATE_FAIL;
@@ -3637,7 +3638,7 @@ getdns_context_get_suffix(getdns_context *context, getdns_list **value)
 	else
 		*value = list;
 
-	return GETDNS_RETURN_GOOD;
+	return r;
 }
 
 getdns_return_t

--- a/src/convert.c
+++ b/src/convert.c
@@ -240,7 +240,7 @@ getdns_rr_dict2wire(
 	if (r != GETDNS_RETURN_GOOD && r != GETDNS_RETURN_NEED_MORE_SPACE)
 		return r;
 
-	if (!(buf = malloc(buf_len)))
+	if (!(buf = malloc(buf_len ? buf_len : 1)))
 		return GETDNS_RETURN_MEMORY_ERROR;
 
 	if (!r)
@@ -658,11 +658,16 @@ _getdns_wire2msg_dict_scan(struct mem_funcs *mf,
 			     result, "question", rr_dict)))
 				goto error;
 			break;
-		default:
+		case GLDNS_SECTION_ANSWER:
+		case GLDNS_SECTION_AUTHORITY:
+		case GLDNS_SECTION_ADDITIONAL:
 			if ((r = _getdns_list_append_this_dict(
 			     sections[section], rr_dict)))
 				goto error;
 			break;
+		default:
+			r = GETDNS_RETURN_GENERIC_ERROR;
+			goto error;
 		}
 		rr_dict = NULL;
 	}
@@ -849,7 +854,7 @@ getdns_msg_dict2wire(
 	if (r != GETDNS_RETURN_GOOD && r != GETDNS_RETURN_NEED_MORE_SPACE)
 		return r;
 
-	if (!(buf = malloc(buf_len)))
+	if (!(buf = malloc(buf_len ? buf_len : 1)))
 		return GETDNS_RETURN_MEMORY_ERROR;
 
 	if (!r)

--- a/src/dict.c
+++ b/src/dict.c
@@ -65,7 +65,7 @@ static char *_json_ptr_first(const struct mem_funcs *mf,
 	if (!(next_ref = strchr(jptr, '/')))
 		next_ref = strchr(jptr, '\0');
 
-	if (next_ref - jptr > first_sz)
+	if (next_ref - jptr + 1 > first_sz || !first)
 		first = GETDNS_XMALLOC(*mf, char, next_ref - jptr + 1);
 
 	for (j = first, k = jptr; k < next_ref; j++, k++)
@@ -484,7 +484,6 @@ _getdns_dict_copy(const struct getdns_dict * srcdict,
 	if (!*dstdict)
 		return GETDNS_RETURN_GENERIC_ERROR;
 
-	retval = GETDNS_RETURN_GOOD;
 	RBTREE_FOR(item, struct getdns_dict_item *,
 		(struct _getdns_rbtree_t *)&(srcdict->root)) {
 		key = (char *) item->node.key;
@@ -507,6 +506,9 @@ _getdns_dict_copy(const struct getdns_dict * srcdict,
 		case t_list:
 			retval = getdns_dict_set_list(*dstdict, key,
 				item->i.data.list);
+			break;
+		default:
+			retval = GETDNS_RETURN_WRONG_TYPE_REQUESTED;
 			break;
 		}
 		if (retval != GETDNS_RETURN_GOOD) {

--- a/src/dnssec.c
+++ b/src/dnssec.c
@@ -828,7 +828,7 @@ static chain_head *add_rrset2val_chain(struct mem_funcs *mf,
 		    ; node = node->parent, n++);
 
 		for ( n -= max_labels, node = max_head->parent
-		    ; n
+		    ; n && node
 		    ; n--, node = node->parent);
 
 		max_node = node;
@@ -2646,8 +2646,8 @@ static int key_proves_nonexistance(
 		for ( i = rrset_iter_init(&i_spc, rrset->pkt, rrset->pkt_len)
 		    ; i ; i = rrset_iter_next(i)) {
 
-			if (   (ce = rrset_iter_value(i))->rr_type
-					!= GETDNS_RRTYPE_NSEC3
+			if (   !(ce = rrset_iter_value(i))
+			    || ce->rr_type != GETDNS_RRTYPE_NSEC3
 
 			    /* Get the bitmap rdata field */
 			    || !(nsec_rr = rrtype_iter_init(&nsec_spc, ce))

--- a/src/gldns/keyraw.c
+++ b/src/gldns/keyraw.c
@@ -206,7 +206,6 @@ gldns_key_buf2dsa_raw(unsigned char* key, size_t len)
 	offset += length;
 
 	Y = BN_bin2bn(key+offset, (int)length, NULL);
-	offset += length;
 
 	/* create the key and set its properties */
 	if(!Q || !P || !G || !Y || !(dsa = DSA_new())) {

--- a/src/gldns/parseutil.c
+++ b/src/gldns/parseutil.c
@@ -637,7 +637,7 @@ int gldns_b64_ntop(uint8_t const *src, size_t srclength,
 		target[o+1] = b64[ ((src[i]&0x03)<<4) | (src[i+1]>>4) ];
 		target[o+2] = b64[ ((src[i+1]&0x0f)<<2) ];
 		target[o+3] = pad64;
-		i += 2;
+		/* i += 2; */
 		o += 4;
 		break;
 	case 1:
@@ -646,7 +646,7 @@ int gldns_b64_ntop(uint8_t const *src, size_t srclength,
 		target[o+1] = b64[ ((src[i]&0x03)<<4) ];
 		target[o+2] = pad64;
 		target[o+3] = pad64;
-		i += 1;
+		/* i += 1; */
 		o += 4;
 		break;
 	case 0:

--- a/src/gldns/str2wire.c
+++ b/src/gldns/str2wire.c
@@ -892,10 +892,10 @@ int gldns_fp2wire_rr_buf(FILE* in, uint8_t* rr, size_t* len, size_t* dname_len,
 			parse_state?parse_state->default_ttl:0,
 			(parse_state&&parse_state->origin_len)?
 				parse_state->origin:NULL,
-			parse_state->origin_len,
+			parse_state?parse_state->origin_len:0,
 			(parse_state&&parse_state->prev_rr_len)?
 				parse_state->prev_rr:NULL,
-			parse_state->prev_rr_len);
+			parse_state?parse_state->prev_rr_len:0);
 	}
 	return GLDNS_WIREPARSE_ERR_OK;
 }

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -691,7 +691,7 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	getdns_dict *add_opt_parameters;
 	int     have_add_opt_parameters;
 
-	getdns_list *options;
+	getdns_list *options = NULL;
 	size_t      noptions = 0;
 	size_t       i;
 

--- a/src/test/check_getdns_context_set_timeout.c
+++ b/src/test/check_getdns_context_set_timeout.c
@@ -206,12 +206,13 @@ void* run_server(void* data) {
             }
             getdns_dict_destroy(dns_msg);
             r = getdns_general_sync(ctxt, qname_str, qtype, NULL, &responses[num_received].reply);
-            free(qname_str);
             if (r) {
                 fprintf( stderr, "Could query for \"%s\" %d: \"%s\"\n", qname_str, (int)qtype
                        , getdns_get_errorstr_by_id(r));
+                free(qname_str);
                 continue;
             }
+            free(qname_str);
             if ((r = getdns_dict_set_int(responses[num_received].reply, "/replies_tree/0/header/id", qid))) {
                 fprintf( stderr, "Could not set message ID on reply dict: \"%s\"\n"
                        , getdns_get_errorstr_by_id(r));

--- a/src/test/getdns_query.c
+++ b/src/test/getdns_query.c
@@ -621,7 +621,7 @@ error:
 	getdns_list_destroy(trust_anchor);
 	getdns_list_destroy(to_validate);
 
-	return GETDNS_RETURN_GOOD;
+	return r;
 }
 
 void callback(getdns_context *context, getdns_callback_type_t callback_type,

--- a/src/test/testmessages.c
+++ b/src/test/testmessages.c
@@ -45,7 +45,6 @@ tstmsg_prog_begin(char *prognm)
 {
 	if (testprog != NULL) {
 		tstmsg_prog_end();
-		free(testprog);
 	}
 	testprog = strdup(prognm);
 	printf("TESTPROG %s START\n", testprog);

--- a/src/test/tests_list.c
+++ b/src/test/tests_list.c
@@ -56,7 +56,7 @@ tst_bindatasetget(void)
 	size_t index = 0;
 	getdns_return_t retval;
 	struct getdns_list *list = NULL;
-	struct getdns_bindata *new_bindata = NULL;
+	struct getdns_bindata  new_bindata = { 0, NULL };
 	struct getdns_bindata *ans_bindata = NULL;
 
 	tstmsg_case_begin("tst_bindatasetget");
@@ -101,12 +101,10 @@ tst_bindatasetget(void)
 
 	/* test set and get legitimate use case */
 
-	new_bindata =
-	    (struct getdns_bindata *) malloc(sizeof(struct getdns_bindata));
-	new_bindata->size = strlen("foobar") + 1;
-	new_bindata->data = (uint8_t *) "foobar";
+	new_bindata.size = strlen("foobar") + 1;
+	new_bindata.data = (uint8_t *) "foobar";
 
-	getdns_list_set_bindata(list, index, new_bindata);
+	getdns_list_set_bindata(list, index, &new_bindata);
 	retval = getdns_list_get_bindata(list, index, &ans_bindata);
 	snprintf(msg, sizeof(msg),
 	    "getdns_list_set/get_bindata,retval = %d, bindata->data = %d,%s",
@@ -378,7 +376,7 @@ tst_create(void)
 
 	tstmsg_case_msg("getdns_list_get_length(list)");
 	retval = getdns_list_get_length(list, &index);
-	snprintf(msg, sizeof(msg), "list length = %d", (int) index);
+	snprintf(msg, sizeof(msg), "list length = %d, retval = %d", (int) index, retval);
 	tstmsg_case_msg(msg);
 
 	tstmsg_case_msg("getdns_list_get_length()");

--- a/src/test/tpkg/100-compile.tpkg/100-compile.pre
+++ b/src/test/tpkg/100-compile.tpkg/100-compile.pre
@@ -25,4 +25,4 @@ done
 rm -fr "${BUILDDIR}/build"
 mkdir  "${BUILDDIR}/build"
 cd "${BUILDDIR}/build"
-"${SRCROOT}/configure" --prefix "${BUILDDIR}/install"
+"${SRCROOT}/configure" $* --prefix "${BUILDDIR}/install"

--- a/src/test/tpkg/125-valgrind-checks.tpkg/125-valgrind-checks.dsc
+++ b/src/test/tpkg/125-valgrind-checks.tpkg/125-valgrind-checks.dsc
@@ -5,7 +5,7 @@ CreationDate: ma mrt 21 15:59:59 CET 2016
 Maintainer: Willem Toorop
 Category: 
 Component:
-CmdDepends: 
+CmdDepends: valgrind
 Depends: 110-link.tpkg
 Help:
 Pre: 

--- a/src/test/tpkg/200-stub-only-compile.tpkg/200-stub-only-compile.pre
+++ b/src/test/tpkg/200-stub-only-compile.tpkg/200-stub-only-compile.pre
@@ -25,4 +25,4 @@ done
 rm -fr "${BUILDDIR}/build-stub-only"
 mkdir  "${BUILDDIR}/build-stub-only"
 cd "${BUILDDIR}/build-stub-only"
-"${SRCROOT}/configure" --enable-stub-only
+"${SRCROOT}/configure" $* --enable-stub-only

--- a/src/test/tpkg/225-stub-only-valgrind-checks.tpkg/225-stub-only-valgrind-checks.dsc
+++ b/src/test/tpkg/225-stub-only-valgrind-checks.tpkg/225-stub-only-valgrind-checks.dsc
@@ -5,7 +5,7 @@ CreationDate: ma mrt 21 16:24:56 CET 2016
 Maintainer: Willem Toorop
 Category: 
 Component:
-CmdDepends: 
+CmdDepends: valgrind
 Depends: 110-link.tpkg
 Help:
 Pre: 

--- a/src/test/tpkg/300-event-loops-configure.tpkg/300-event-loops-configure.test
+++ b/src/test/tpkg/300-event-loops-configure.tpkg/300-event-loops-configure.test
@@ -7,10 +7,10 @@
 rm -fr "${BUILDDIR}/build-event-loops"
 mkdir  "${BUILDDIR}/build-event-loops"
 cd "${BUILDDIR}/build-event-loops"
-"${SRCROOT}/configure" --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent --with-libev --with-libuv \
-    || "${SRCROOT}/configure" --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent --with-libev \
-    || "${SRCROOT}/configure" --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent --with-libuv \
-    || "${SRCROOT}/configure" --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libev --with-libuv \
-    || "${SRCROOT}/configure" --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent \
-    || "${SRCROOT}/configure" --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libev \
-    || "${SRCROOT}/configure" --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libuv
+"${SRCROOT}/configure" $* --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent --with-libev --with-libuv \
+    || "${SRCROOT}/configure" $* --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent --with-libev \
+    || "${SRCROOT}/configure" $* --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent --with-libuv \
+    || "${SRCROOT}/configure" $* --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libev --with-libuv \
+    || "${SRCROOT}/configure" $* --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libevent \
+    || "${SRCROOT}/configure" $* --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libev \
+    || "${SRCROOT}/configure" $* --enable-all-drafts --enable-all-debugging --with-getdns_query --with-libuv

--- a/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.dsc
+++ b/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.dsc
@@ -1,0 +1,16 @@
+BaseName: 340-event-loops-scan-build
+Version: 1.0
+Description: Compile
+CreationDate: do 28 apr 2016 16:50:43 CEST
+Maintainer: Willem Toorop
+Category: 
+Component:
+CmdDepends: scan-build
+Depends: 300-event-loops-configure.tpkg
+Help:
+Pre: 340-event-loops-scan-build.pre
+Post: 340-event-loops-scan-build.post
+Test: 340-event-loops-scan-build.test
+AuxFiles: 
+Passed:
+Failure:

--- a/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.post
+++ b/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.post
@@ -1,0 +1,20 @@
+# #-- 340-event-loops-scan-build.post --#
+# source the master var file when it's there
+if [ -f ../.tpkg.var.master ]
+then
+	source ../.tpkg.var.master
+else
+	(
+		cd ..
+		[ -f  "${TPKG_SRCDIR}/setup-env.sh" ] \
+		    && sh "${TPKG_SRCDIR}/setup-env.sh"
+	) && source ../.tpkg.var.master
+fi
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+
+for f in `cat restore-srcdir-configure-settings`
+do
+	mv "${SRCROOT}/${f}.build-event-loops" "${SRCROOT}/${f}"
+done
+

--- a/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.pre
+++ b/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.pre
@@ -1,0 +1,24 @@
+# #-- 340-event-loops-scan-build.pre--#
+# source the master var file when it's there
+if [ -f ../.tpkg.var.master ]
+then
+	source ../.tpkg.var.master
+else
+	(
+		cd ..
+		[ -f  "${TPKG_SRCDIR}/setup-env.sh" ] \
+		    && sh "${TPKG_SRCDIR}/setup-env.sh" 
+	) && source ../.tpkg.var.master
+fi
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+
+echo "" > restore-srcdir-configure-settings
+for f in `grep 'CONFIG_[FH][IE][LA][ED][SE]' "${SRCROOT}/configure.ac" | sed -e 's/^.*(\[//g' -e 's/\])//g'`
+do
+	if [ -f "${SRCROOT}/$f" ]
+	then
+		mv "${SRCROOT}/${f}" "${SRCROOT}/${f}.build-event-loops" && \
+			echo "$f" >> restore-srcdir-configure-settings
+	fi
+done

--- a/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.test
+++ b/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.test
@@ -4,13 +4,6 @@
 # use .tpkg.var.test for in test variable passing
 [ -f .tpkg.var.test ] && source .tpkg.var.test
 
-(
-	cd "${BUILDDIR}/build-event-loops"
-	make clean
-	scan-build -o ../scan-build-reports -v make everything
-) && if grep "No bugs found" result.340-event-loops-scan-build
-then
-	exit 0
-else
-	exit 1
-fi
+cd "${BUILDDIR}/build-event-loops"
+make clean
+scan-build -o ../scan-build-reports -v --status-bugs make everything

--- a/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.test
+++ b/src/test/tpkg/340-event-loops-scan-build.tpkg/340-event-loops-scan-build.test
@@ -1,0 +1,16 @@
+# #-- 340-event-loops-scan-build.test --#
+# source the master var file when it's there
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+# use .tpkg.var.test for in test variable passing
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+
+(
+	cd "${BUILDDIR}/build-event-loops"
+	make clean
+	scan-build -o ../scan-build-reports -v make everything
+) && if grep "No bugs found" result.340-event-loops-scan-build
+then
+	exit 0
+else
+	exit 1
+fi

--- a/src/test/tpkg/tpkg
+++ b/src/test/tpkg/tpkg
@@ -414,7 +414,13 @@ do case "$o" in
 	v) 	version; exit 0;;
         l)      TPKG_LOG=1;;
         p)      TPKG_PRI="$OPTARG";;
-	a) 	TPKG_ARGS="$OPTARG";;
+	a) 	if [ -z "$TPKG_ARGS" ]
+		then
+			TPKG_ARGS="$OPTARG"
+		else
+			TPKG_ARGS="$TPKG_ARGS $OPTARG"
+		fi
+		;;
         q)      TPKG_QUIET=1;;
         k)      TPKG_KEEP=1;;
         n)      TPKG_PASS=$OPTARG

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -493,8 +493,7 @@ _getdns_create_reply_dict(getdns_context *context, getdns_network_req *req,
 	gldns_pkt_section section;
 	uint8_t canonical_name_space[256], owner_name_space[256],
 	    query_name_space[256];
-	const uint8_t *canonical_name = canonical_name_space, *owner_name,
-	    *query_name;
+	const uint8_t *canonical_name, *owner_name, *query_name;
 	size_t canonical_name_len = sizeof(canonical_name_space),
 	       owner_name_len = sizeof(owner_name_space),
 	       query_name_len = sizeof(query_name_space);


### PR DESCRIPTION
Parameters to run-all.sh and run-all-lcov.sh are passed to tpkg.  The tpkg scripts pass their arguments to configure before compile.  As a consequence alternative locations for libraries can be passed by giving -a options.  Multiple -a options can be given each specifying a single argument for the call to configure.  For example:

`src/test/tpkg/run-all.sh -a --with-ssl=$HOME/local -a --with-libunbound=$HOME/local`
