### PR TITLE
Return call_reporting info in case of timeout, so that we can see which server did not respond.

### DIFF
--- a/src/dnssec.c
+++ b/src/dnssec.c
@@ -2776,19 +2776,13 @@ static size_t count_outstanding_requests(chain_head *head)
 
 		count += node->lock;
 
-		if (node->dnskey_req &&
-		    node->dnskey_req->state != NET_REQ_FINISHED &&
-		    node->dnskey_req->state != NET_REQ_CANCELED)
+		if (!_getdns_netreq_finished(node->dnskey_req))
 			count++;
 
-		if (node->ds_req &&
-		    node->ds_req->state != NET_REQ_FINISHED &&
-		    node->ds_req->state != NET_REQ_CANCELED)
+		if (!_getdns_netreq_finished(node->ds_req))
 			count++;
 
-		if (node->soa_req &&
-		    node->soa_req->state != NET_REQ_FINISHED &&
-		    node->soa_req->state != NET_REQ_CANCELED)
+		if (!_getdns_netreq_finished(node->soa_req))
 			count++;
 	}
 	return count + count_outstanding_requests(head->next);

--- a/src/general.c
+++ b/src/general.c
@@ -104,8 +104,7 @@ _getdns_check_dns_req_complete(getdns_dns_req *dns_req)
 	int results_found = 0, r;
 	
 	for (netreq_p = dns_req->netreqs; (netreq = *netreq_p); netreq_p++)
-		if (netreq->state != NET_REQ_FINISHED &&
-		    netreq->state != NET_REQ_CANCELED)
+		if (!_getdns_netreq_finished(netreq))
 			return;
 		else if (netreq->response_len > 0)
 			results_found = 1;

--- a/src/stub.c
+++ b/src/stub.c
@@ -565,14 +565,12 @@ stub_timeout_cb(void *userarg)
 	stub_next_upstream(netreq);
 	stub_cleanup(netreq);
 	if (netreq->fd >= 0) close(netreq->fd);
-	if (netreq->owner->user_callback) {
-		netreq->state = NET_REQ_TIMED_OUT;
+	netreq->state = NET_REQ_TIMED_OUT;
+	if (netreq->owner->user_callback) {		
 		netreq->debug_end_time = _getdns_get_time_as_uintt64();
 		(void) _getdns_context_request_timed_out(netreq->owner);
-	} else {
-		netreq->state = NET_REQ_FINISHED;
+	} else
 		_getdns_check_dns_req_complete(netreq->owner);
-	}
 }
 
 

--- a/src/stub.c
+++ b/src/stub.c
@@ -91,7 +91,7 @@ static int  upstream_connect(getdns_upstream *upstream,
 static int  fallback_on_write(getdns_network_req *netreq);
 
 static void stub_timeout_cb(void *userarg);
-static uint64_t _getdns_get_time_as_uintt64()
+static uint64_t _getdns_get_time_as_uintt64();
 /*****************************/
 /* General utility functions */
 /*****************************/

--- a/src/stub.c
+++ b/src/stub.c
@@ -91,6 +91,7 @@ static int  upstream_connect(getdns_upstream *upstream,
 static int  fallback_on_write(getdns_network_req *netreq);
 
 static void stub_timeout_cb(void *userarg);
+static uint64_t _getdns_get_time_as_uintt64()
 /*****************************/
 /* General utility functions */
 /*****************************/
@@ -564,9 +565,11 @@ stub_timeout_cb(void *userarg)
 	stub_next_upstream(netreq);
 	stub_cleanup(netreq);
 	if (netreq->fd >= 0) close(netreq->fd);
-	if (netreq->owner->user_callback)
+	if (netreq->owner->user_callback) {
+		netreq->state = NET_REQ_TIMED_OUT;
+		netreq->debug_end_time = _getdns_get_time_as_uintt64();
 		(void) _getdns_context_request_timed_out(netreq->owner);
-	else {
+	} else {
 		netreq->state = NET_REQ_FINISHED;
 		_getdns_check_dns_req_complete(netreq->owner);
 	}

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -154,11 +154,12 @@ priv_getdns_context_mf(getdns_context *context);
 
 typedef enum network_req_state_enum
 {
-	NET_REQ_NOT_SENT,
-	NET_REQ_IN_FLIGHT,
-	NET_REQ_FINISHED,
-	NET_REQ_CANCELED,
-	NET_REQ_TIMED_OUT
+	NET_REQ_NOT_SENT  =  0,
+	NET_REQ_IN_FLIGHT =  1,
+	NET_REQ_FINISHED  =  2, /* Finish type in bits 2 and 3 */
+	NET_REQ_CANCELED  =  6, /* 2 + (1 << 2) */
+	NET_REQ_TIMED_OUT = 10, /* 2 + (2 << 2) */
+	NET_REQ_ERRORED   = 14  /* 2 + (3 << 2) */
 } network_req_state;
 
 
@@ -256,10 +257,11 @@ typedef struct getdns_network_req
 	uint8_t *response;
 	size_t   wire_data_sz;
 	uint8_t  wire_data[];
-
-
 	
 } getdns_network_req;
+
+static inline int _getdns_netreq_finished(getdns_network_req *req)
+{ return !req || (req->state & NET_REQ_FINISHED); }
 
 /**
  * dns request - manages a number of network requests and

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -157,7 +157,8 @@ typedef enum network_req_state_enum
 	NET_REQ_NOT_SENT,
 	NET_REQ_IN_FLIGHT,
 	NET_REQ_FINISHED,
-	NET_REQ_CANCELED
+	NET_REQ_CANCELED,
+	NET_REQ_TIMED_OUT
 } network_req_state;
 
 

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -1189,6 +1189,25 @@ _getdns_create_getdns_response(getdns_dns_req *completed_request)
 		    netreq->response_len, netreq->response))
 			goto error;
     	}
+		if (!nreplies && call_reporting) {
+			for ( netreq_p = completed_request->netreqs
+				  ; (netreq = *netreq_p) ; netreq_p++) {
+				/* Add call_reporting info for timed out request */
+				if (netreq->state == NET_REQ_TIMED_OUT) {
+					if (!(netreq_debug =
+						  _getdns_create_call_reporting_dict(context,netreq)))
+						goto error;
+
+					if (_getdns_list_append_this_dict(
+							call_reporting, netreq_debug)) {
+
+						getdns_dict_destroy(netreq_debug);
+						goto error;
+					}
+				}
+			}
+		}
+
     	if (_getdns_dict_set_this_list(result, "replies_tree", replies_tree))
 		goto error;
 	replies_tree = NULL;


### PR DESCRIPTION
Hi Willem,
I've made a small extension to also populate the call_reporting info in case a query timed out. This way the application can see which of the upstream servers caused the timeout (and how long the timeout was).

Before:
```
Reply: {
  "answer_type": GETDNS_NAMETYPE_DNS,
  "call_reporting": [],
  "replies_full": [],
  "replies_tree": [],
  "status": GETDNS_RESPSTATUS_ALL_TIMEOUT
}

```
After:
```
Reply: {
  "answer_type": GETDNS_NAMETYPE_DNS,
  "call_reporting":
  [
    {
      "query_name": <bindata of "1.2.3.4.5.6.7.4.2.3.e164.org.">,
      "query_to":
      {
        "address_data": <bindata for 192.168.99.122>,
        "address_type": <bindata of "IPv4">
      },
      "query_type": GETDNS_RRTYPE_NAPTR,
      "run_time/ms": 1000,
      "transport": GETDNS_TRANSPORT_UDP
    }
  ],
  "replies_full": [],
  "replies_tree": [],
  "status": GETDNS_RESPSTATUS_ALL_TIMEOUT
}
```

Please consider including this extension.

Cheers,
Robert