### PR TITLE
pthread-based locking for arc4random

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -644,7 +644,7 @@ CHECK_CFLAGS=""
 PKG_CHECK_MODULES([CHECK],[check >= 0.9.6],[CHECK_GETDNS="check_getdns"],[
 AC_SEARCH_LIBS([floor], [m])
 AC_SEARCH_LIBS([timer_create], [rt])
-AC_SEARCH_LIBS([pthread_create], [pthread])
+AC_SEARCH_LIBS([pthread_create], [pthread], [AC_DEFINE([HAVE_PTHREADS], [1], [Define if pthreads exist.])])
 AC_SEARCH_LIBS([srunner_create],[check check_pic],[
 CHECK_GETDNS="check_getdns"
 CHECK_LIBS="$LIBS"],[

--- a/configure.ac
+++ b/configure.ac
@@ -644,7 +644,7 @@ CHECK_CFLAGS=""
 PKG_CHECK_MODULES([CHECK],[check >= 0.9.6],[CHECK_GETDNS="check_getdns"],[
 AC_SEARCH_LIBS([floor], [m])
 AC_SEARCH_LIBS([timer_create], [rt])
-AC_SEARCH_LIBS([pthread_create], [pthread], [AC_DEFINE([HAVE_PTHREADS], [1], [Define if pthreads exist.])])
+AC_SEARCH_LIBS([pthread_create], [pthread])
 AC_SEARCH_LIBS([srunner_create],[check check_pic],[
 CHECK_GETDNS="check_getdns"
 CHECK_LIBS="$LIBS"],[
@@ -922,6 +922,10 @@ AC_CONFIG_FILES([Makefile src/Makefile src/version.c src/getdns/getdns.h src/get
 if [ test -n "$DOXYGEN" ]
     then AC_CONFIG_FILES([src/Doxyfile])
 fi
+
+
+#---- check for pthreads library
+AC_SEARCH_LIBS([pthread_mutex_init],[pthread],[AC_DEFINE([HAVE_PTHREADS], [1], [Have pthreads library])], [AC_MSG_WARN([pthreads not available])])
 
 
 dnl -----

--- a/src/compat/arc4_lock.c
+++ b/src/compat/arc4_lock.c
@@ -34,6 +34,23 @@
 #include "config.h"
 #define LOCKRET(func) func
 
+#ifdef HAVE_PTHREADS
+#include "pthread.h"
+
+static pthread_mutex_t arc_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void _ARC4_LOCK(void)
+{
+    pthread_mutex_lock(&arc_lock);
+}
+
+void _ARC4_UNLOCK(void)
+{
+    pthread_mutex_unlock(&arc_lock);
+}
+
+#else
+/* XXX - add windows-(or at least non pthread) specific lock routines here */
 void _ARC4_LOCK(void)
 {
 }
@@ -41,4 +58,4 @@ void _ARC4_LOCK(void)
 void _ARC4_UNLOCK(void)
 {
 }
-
+#endif


### PR DESCRIPTION
For systems with no pthreads library (i.e. Windows), _ARC4_LOCK() and _ARC4_UNLOCK() are still stubs, which needs to be addressed by someone with Windows knowledge.