### PR TITLE
Fixed eventloop

### DIFF
--- a/src/extension/default_eventloop.c
+++ b/src/extension/default_eventloop.c
@@ -30,9 +30,6 @@
 #include "extension/default_eventloop.h"
 #include "debug.h"
 
-static int max_fds = 0;
-static int max_timeouts = 0;
-
 static uint64_t get_now_plus(uint64_t amount)
 {
 	struct timeval tv;
@@ -55,14 +52,14 @@ default_eventloop_schedule(getdns_eventloop *loop,
 	size_t i;
 
 	DEBUG_SCHED( "%s(loop: %p, fd: %d, timeout: %"PRIu64", event: %p, max_fds: %d)\n"
-	        , __FUNCTION__, loop, fd, timeout, event, max_fds);
+	        , __FUNCTION__, loop, fd, timeout, event, default_loop->max_fds);
 
 	if (!loop || !event)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	if (fd >= (int)max_fds) {
+	if (fd >= (int)default_loop->max_fds) {
 		DEBUG_SCHED( "ERROR: fd %d >= max_fds: %d!\n"
-		           , fd, max_fds);
+		           , fd, default_loop->max_fds);
 		return GETDNS_RETURN_GENERIC_ERROR;
 	}
 	if (fd >= 0 && !(event->read_cb || event->write_cb)) {
@@ -103,7 +100,7 @@ default_eventloop_schedule(getdns_eventloop *loop,
 		DEBUG_SCHED("ERROR: timeout event with write_cb! Clearing.\n");
 		event->write_cb = NULL;
 	}
-	for (i = 0; i < max_timeouts; i++) {
+	for (i = 0; i < default_loop->max_timeouts; i++) {
 		if (default_loop->timeout_events[i] == NULL) {
 			default_loop->timeout_events[i] = event;
 			default_loop->timeout_times[i] = get_now_plus(timeout);
@@ -129,7 +126,7 @@ default_eventloop_clear(getdns_eventloop *loop, getdns_eventloop_event *event)
 	DEBUG_SCHED( "%s(loop: %p, event: %p)\n", __FUNCTION__, loop, event);
 
 	i = (intptr_t)event->ev - 1;
-	if (i < 0 || i > max_fds) {
+	if (i < 0 || i > default_loop->max_fds) {
 		return GETDNS_RETURN_GENERIC_ERROR;
 	}
 	if (event->timeout_cb && !event->read_cb && !event->write_cb) {
@@ -205,7 +202,7 @@ default_eventloop_run_once(getdns_eventloop *loop, int blocking)
 	
 	now = get_now_plus(0);
 
-	for (i = 0; i < max_timeouts; i++) {
+	for (i = 0; i < default_loop->max_timeouts; i++) {
 		if (!default_loop->timeout_events[i])
 			continue;
 		if (now > default_loop->timeout_times[i])
@@ -214,7 +211,7 @@ default_eventloop_run_once(getdns_eventloop *loop, int blocking)
 			timeout = default_loop->timeout_times[i];
 	}
 	// first we count the number of fds that will be active
-	for (fd = 0; fd < max_fds; fd++) {
+	for (fd = 0; fd < default_loop->max_fds; fd++) {
 		if (!default_loop->fd_events[fd])
 			continue;
 		if (default_loop->fd_events[fd]->read_cb ||
@@ -230,7 +227,7 @@ default_eventloop_run_once(getdns_eventloop *loop, int blocking)
 		return;
 
 	pfds = calloc(num_pfds, sizeof(struct pollfd));
-	for (fd = 0, i=0; fd < max_fds; fd++) {
+	for (fd = 0, i=0; fd < default_loop->max_fds; fd++) {
 		if (!default_loop->fd_events[fd])
 			continue;
 		if (default_loop->fd_events[fd]->read_cb) {
@@ -267,7 +264,7 @@ default_eventloop_run_once(getdns_eventloop *loop, int blocking)
 	}
 	if (pfds)
 		free(pfds);
-	for (int fd=0; fd < max_fds; fd++) {
+	for (int fd=0; fd < default_loop->max_fds; fd++) {
 		if (default_loop->fd_events[fd] &&
 		    default_loop->fd_events[fd]->timeout_cb &&
 		    now > default_loop->fd_timeout_times[fd])
@@ -290,7 +287,7 @@ default_eventloop_run(getdns_eventloop *loop)
 		return;
 
 	i = 0;
-	while (i < max_timeouts) {
+	while (i < default_loop->max_timeouts) {
 		if (default_loop->fd_events[i] || default_loop->timeout_events[i]) {
 			default_eventloop_run_once(loop, 1);
 			i = 0;
@@ -316,19 +313,19 @@ _getdns_default_eventloop_init(_getdns_default_eventloop *loop)
 
 	struct rlimit rl;
 	if (getrlimit(RLIMIT_NOFILE, &rl) == 0) {
-		max_fds = rl.rlim_cur;
-		max_timeouts = max_fds;
+		loop->max_fds = rl.rlim_cur;
+		loop->max_timeouts = loop->max_fds;
 	} else {
 		DEBUG_SCHED("ERROR: could not obtain RLIMIT_NOFILE from getrlimit()\n");
-		max_fds = 0;
-		max_timeouts = max_fds;
+		loop->max_fds = 0;
+		loop->max_timeouts = loop->max_fds;
 	}
-	if (max_fds) {
-		loop->fd_events = calloc(max_fds, sizeof(getdns_eventloop_event *));
-		loop->fd_timeout_times = calloc(max_fds, sizeof(uint64_t));
+	if (loop->max_fds) {
+		loop->fd_events = calloc(loop->max_fds, sizeof(getdns_eventloop_event *));
+		loop->fd_timeout_times = calloc(loop->max_fds, sizeof(uint64_t));
 	}
-	if (max_timeouts) {
-		loop->timeout_events = calloc(max_timeouts, sizeof(getdns_eventloop_event *));
-		loop->timeout_times = calloc(max_timeouts, sizeof(uint64_t));
+	if (loop->max_timeouts) {
+		loop->timeout_events = calloc(loop->max_timeouts, sizeof(getdns_eventloop_event *));
+		loop->timeout_times = calloc(loop->max_timeouts, sizeof(uint64_t));
 	}
 }

--- a/src/extension/default_eventloop.c
+++ b/src/extension/default_eventloop.c
@@ -25,8 +25,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <poll.h>
+#include <sys/resource.h>
 #include "extension/default_eventloop.h"
 #include "debug.h"
+
+static int max_fds = 0;
+static int max_timeouts = 0;
 
 static uint64_t get_now_plus(uint64_t amount)
 {
@@ -49,15 +54,15 @@ default_eventloop_schedule(getdns_eventloop *loop,
 	_getdns_default_eventloop *default_loop  = (_getdns_default_eventloop *)loop;
 	size_t i;
 
-	DEBUG_SCHED( "%s(loop: %p, fd: %d, timeout: %"PRIu64", event: %p, FD_SETSIZE: %d)\n"
-	        , __FUNCTION__, loop, fd, timeout, event, FD_SETSIZE);
+	DEBUG_SCHED( "%s(loop: %p, fd: %d, timeout: %"PRIu64", event: %p, max_fds: %d)\n"
+	        , __FUNCTION__, loop, fd, timeout, event, max_fds);
 
 	if (!loop || !event)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	if (fd >= (int)FD_SETSIZE) {
-		DEBUG_SCHED( "ERROR: fd %d >= FD_SETSIZE: %d!\n"
-		           , fd, FD_SETSIZE);
+	if (fd >= (int)max_fds) {
+		DEBUG_SCHED( "ERROR: fd %d >= max_fds: %d!\n"
+		           , fd, max_fds);
 		return GETDNS_RETURN_GENERIC_ERROR;
 	}
 	if (fd >= 0 && !(event->read_cb || event->write_cb)) {
@@ -98,7 +103,7 @@ default_eventloop_schedule(getdns_eventloop *loop,
 		DEBUG_SCHED("ERROR: timeout event with write_cb! Clearing.\n");
 		event->write_cb = NULL;
 	}
-	for (i = 0; i < MAX_TIMEOUTS; i++) {
+	for (i = 0; i < max_timeouts; i++) {
 		if (default_loop->timeout_events[i] == NULL) {
 			default_loop->timeout_events[i] = event;
 			default_loop->timeout_times[i] = get_now_plus(timeout);
@@ -124,7 +129,7 @@ default_eventloop_clear(getdns_eventloop *loop, getdns_eventloop_event *event)
 	DEBUG_SCHED( "%s(loop: %p, event: %p)\n", __FUNCTION__, loop, event);
 
 	i = (intptr_t)event->ev - 1;
-	if (i < 0 || i > FD_SETSIZE) {
+	if (i < 0 || i > max_fds) {
 		return GETDNS_RETURN_GENERIC_ERROR;
 	}
 	if (event->timeout_cb && !event->read_cb && !event->write_cb) {
@@ -151,6 +156,15 @@ default_eventloop_clear(getdns_eventloop *loop, getdns_eventloop_event *event)
 static void
 default_eventloop_cleanup(getdns_eventloop *loop)
 {
+	_getdns_default_eventloop *default_loop  = (_getdns_default_eventloop *)loop;
+	if (default_loop->fd_events)
+		free(default_loop->fd_events);
+	if (default_loop->fd_timeout_times)
+		free(default_loop->fd_timeout_times);
+	if (default_loop->timeout_events)
+		free(default_loop->timeout_events);
+	if (default_loop->timeout_times)
+		free(default_loop->timeout_times);
 }
 
 static void
@@ -179,20 +193,19 @@ default_eventloop_run_once(getdns_eventloop *loop, int blocking)
 {
 	_getdns_default_eventloop *default_loop  = (_getdns_default_eventloop *)loop;
 
-	fd_set   readfds, writefds;
 	int      fd, max_fd = -1;
 	uint64_t now, timeout = (uint64_t)-1;
 	size_t   i;
-	struct timeval tv;
-
+	int poll_timeout = 0;
+	struct pollfd* pfds = NULL;
+	int num_pfds = 0;
+	
 	if (!loop)
 		return;
-
-	FD_ZERO(&readfds);
-	FD_ZERO(&writefds);
+	
 	now = get_now_plus(0);
 
-	for (i = 0; i < MAX_TIMEOUTS; i++) {
+	for (i = 0; i < max_timeouts; i++) {
 		if (!default_loop->timeout_events[i])
 			continue;
 		if (now > default_loop->timeout_times[i])
@@ -200,50 +213,65 @@ default_eventloop_run_once(getdns_eventloop *loop, int blocking)
 		else if (default_loop->timeout_times[i] < timeout)
 			timeout = default_loop->timeout_times[i];
 	}
-	for (fd = 0; fd < FD_SETSIZE; fd++) {
+	// first we count the number of fds that will be active
+	for (fd = 0; fd < max_fds; fd++) {
 		if (!default_loop->fd_events[fd])
 			continue;
-		if (default_loop->fd_events[fd]->read_cb)
-			FD_SET(fd, &readfds);
-		if (default_loop->fd_events[fd]->write_cb)
-			FD_SET(fd, &writefds);
+		if (default_loop->fd_events[fd]->read_cb ||
+		    default_loop->fd_events[fd]->write_cb)
+			num_pfds++;
 		if (fd > max_fd)
 			max_fd = fd;
 		if (default_loop->fd_timeout_times[fd] < timeout)
 			timeout = default_loop->fd_timeout_times[fd];
 	}
-	if (max_fd == -1 && timeout == (uint64_t)-1)
+
+	if ((max_fd == -1 && timeout == (uint64_t)-1) || (num_pfds == 0))
 		return;
 
-	if (! blocking || now > timeout) {
-		tv.tv_sec = 0;
-		tv.tv_usec = 0;
-	} else {
-		tv.tv_sec  = (timeout - now) / 1000000;
-		tv.tv_usec = (timeout - now) % 1000000;
+	pfds = calloc(num_pfds, sizeof(struct pollfd));
+	for (fd = 0, i=0; fd < max_fds; fd++) {
+		if (!default_loop->fd_events[fd])
+			continue;
+		if (default_loop->fd_events[fd]->read_cb) {
+			pfds[i].fd = fd;
+			pfds[i].events |= POLLIN;
+		}	
+		if (default_loop->fd_events[fd]->write_cb) {
+			pfds[i].fd = fd;
+			pfds[i].events |= POLLOUT;
+		}
 	}
-	if (select(max_fd + 1, &readfds, &writefds, NULL,
-	    (timeout == ((uint64_t)-1) ? NULL : &tv)) < 0) {
-		perror("select() failed");
+
+	if (! blocking || now > timeout) {
+		poll_timeout = 0;
+	} else {
+		poll_timeout = (timeout - now) * 1000; /* turn seconds in millseconds */
+	}
+	if (poll(pfds, num_pfds, poll_timeout) < 0) {
+		perror("poll() failed");
 		exit(EXIT_FAILURE);
 	}
 	now = get_now_plus(0);
-	for (fd = 0; fd < FD_SETSIZE; fd++) {
+	for (int i = 0; i < num_pfds; i++) {
+		int fd = pfds[i].fd;
 		if (default_loop->fd_events[fd] &&
 		    default_loop->fd_events[fd]->read_cb &&
-		    FD_ISSET(fd, &readfds))
+		    (pfds[i].revents & POLLIN))
 			default_read_cb(fd, default_loop->fd_events[fd]);
 
 		if (default_loop->fd_events[fd] &&
 		    default_loop->fd_events[fd]->write_cb &&
-		    FD_ISSET(fd, &writefds))
+		    (pfds[i].revents & POLLOUT))
 			default_write_cb(fd, default_loop->fd_events[fd]);
-
+	}
+	if (pfds)
+		free(pfds);
+	for (int fd=0; fd < max_fds; fd++) {
 		if (default_loop->fd_events[fd] &&
 		    default_loop->fd_events[fd]->timeout_cb &&
 		    now > default_loop->fd_timeout_times[fd])
 			default_timeout_cb(fd, default_loop->fd_events[fd]);
-
 		i = fd;
 		if (default_loop->timeout_events[i] &&
 		    default_loop->timeout_events[i]->timeout_cb &&
@@ -262,7 +290,7 @@ default_eventloop_run(getdns_eventloop *loop)
 		return;
 
 	i = 0;
-	while (i < MAX_TIMEOUTS) {
+	while (i < max_timeouts) {
 		if (default_loop->fd_events[i] || default_loop->timeout_events[i]) {
 			default_eventloop_run_once(loop, 1);
 			i = 0;
@@ -285,4 +313,22 @@ _getdns_default_eventloop_init(_getdns_default_eventloop *loop)
 
 	(void) memset(loop, 0, sizeof(_getdns_default_eventloop));
 	loop->loop.vmt = &default_eventloop_vmt;
+
+	struct rlimit rl;
+	if (getrlimit(RLIMIT_NOFILE, &rl) == 0) {
+		max_fds = rl.rlim_cur;
+		max_timeouts = max_fds;
+	} else {
+		DEBUG_SCHED("ERROR: could not obtain RLIMIT_NOFILE from getrlimit()\n");
+		max_fds = 0;
+		max_timeouts = max_fds;
+	}
+	if (max_fds) {
+		loop->fd_events = calloc(max_fds, sizeof(getdns_eventloop_event *));
+		loop->fd_timeout_times = calloc(max_fds, sizeof(uint64_t));
+	}
+	if (max_timeouts) {
+		loop->timeout_events = calloc(max_timeouts, sizeof(getdns_eventloop_event *));
+		loop->timeout_times = calloc(max_timeouts, sizeof(uint64_t));
+	}
 }

--- a/src/extension/default_eventloop.h
+++ b/src/extension/default_eventloop.h
@@ -38,6 +38,8 @@
 /* Eventloop based on poll */
 typedef struct _getdns_default_eventloop {
 	getdns_eventloop        loop;
+	int			max_fds;
+	int			max_timeouts;
 	getdns_eventloop_event **fd_events;
 	uint64_t                *fd_timeout_times;
 	getdns_eventloop_event **timeout_events;

--- a/src/extension/default_eventloop.h
+++ b/src/extension/default_eventloop.h
@@ -35,20 +35,13 @@
 #include "getdns/getdns.h"
 #include "getdns/getdns_extra.h"
 
-/* No more than select's capability queries can be outstanding,
- * The number of outstanding timeouts should be less or equal then
- * the number of outstanding queries, so MAX_TIMEOUTS equal to
- * FD_SETSIZE should be safe.
- */
-#define MAX_TIMEOUTS FD_SETSIZE
-
-/* Eventloop based on select */
+/* Eventloop based on poll */
 typedef struct _getdns_default_eventloop {
 	getdns_eventloop        loop;
-	getdns_eventloop_event *fd_events[FD_SETSIZE];
-	uint64_t                fd_timeout_times[FD_SETSIZE];
-	getdns_eventloop_event *timeout_events[MAX_TIMEOUTS];
-	uint64_t                timeout_times[MAX_TIMEOUTS];
+	getdns_eventloop_event **fd_events;
+	uint64_t                *fd_timeout_times;
+	getdns_eventloop_event **timeout_events;
+	uint64_t                *timeout_times;
 } _getdns_default_eventloop;
 
 


### PR DESCRIPTION
This fixes* the issues with default_eventloop by doing the following:

- Use poll() instead of select() so that fds with a value >1024 can be used
- Dynamically allocate the default_eventloop arrays based on RLIMIT_NOFILE (rlimit_cur)

This means that as long as the soft limit is set high enough, there will not be issues with high numbers of file descriptors being used.

*However, this is not an ideal fix. Using an array sized by the maximum number of file descriptors seems to be incredibly inefficient. It would be better if this were simply an array of the file descriptors currently in-use, however that requires more drastic changes to the way default_eventloop works.