### PR TITLE
Fixing the bulk of the compilation warnings in the GetDNS code

### DIFF
--- a/src/compat/arc4random_uniform.c
+++ b/src/compat/arc4random_uniform.c
@@ -39,7 +39,7 @@ arc4random_uniform(uint32_t upper_bound)
 		return 0;
 
 	/* 2**32 % x == (2**32 - x) % x */
-	min = -upper_bound % upper_bound;
+	min = ((uint32_t)(-(int32_t)upper_bound)) % upper_bound;
 
 	/*
 	 * This could theoretically loop forever but each retry has

--- a/src/convert.c
+++ b/src/convert.c
@@ -56,6 +56,14 @@
 /* stuff to make it compile pedantically */
 #define UNUSED_PARAM(x) ((void)(x))
 
+/* strdup is marked deprecated by the Windows compiler */
+#ifndef STRDUP
+#ifdef GETDNS_ON_WINDOWS
+#define STRDUP(x) _strdup(x)
+#else
+#define STRDUP(x) strdup(x)
+#endif
+#endif
 getdns_return_t
 getdns_convert_dns_name_to_fqdn(
     const getdns_bindata *dns_name_wire_fmt, char **fqdn_as_string)
@@ -200,7 +208,7 @@ getdns_display_ip_address(const struct getdns_bindata
 		    buff,
 		    256);
 		if (ipStr) {
-			return strdup(ipStr);
+			return STRDUP(ipStr);
 		}
 	} else if (bindata_of_ipv4_or_ipv6_address->size == 16) {
 		const char *ipStr = inet_ntop(AF_INET6,
@@ -208,7 +216,7 @@ getdns_display_ip_address(const struct getdns_bindata
 		    buff,
 		    256);
 		if (ipStr) {
-			return strdup(ipStr);
+			return STRDUP(ipStr);
 		}
 	}
 	return NULL;

--- a/src/dict.c
+++ b/src/dict.c
@@ -65,7 +65,7 @@ static char *_json_ptr_first(const struct mem_funcs *mf,
 	if (!(next_ref = strchr(jptr, '/')))
 		next_ref = strchr(jptr, '\0');
 
-	if (next_ref - jptr + 1 > first_sz || !first)
+	if ((unsigned)(next_ref - jptr + 1) > first_sz || !first)
 		first = GETDNS_XMALLOC(*mf, char, next_ref - jptr + 1);
 
 	for (j = first, k = jptr; k < next_ref; j++, k++)

--- a/src/dnssec.c
+++ b/src/dnssec.c
@@ -256,7 +256,7 @@ static uint8_t *_dname_label_copy(uint8_t *dst, const uint8_t *src, size_t dst_l
 {
 	uint8_t *r = dst, i;
 
-	if (!src || *src + 1 > dst_len)
+	if (!src || (unsigned)(*src + 1) > dst_len)
 		return NULL;
 
 	for (i = (*dst++ = *src++); i ; i--)
@@ -559,7 +559,7 @@ static chain_head *add_rrset2val_chain(struct mem_funcs *mf,
 			if (! _dname_is_parent(*label, head->rrset.name))
 				break;
 		}
-		if (label - labels > max_labels) {
+		if ((unsigned)(label - labels) > max_labels) {
 			max_labels = label - labels;
 			max_head = head;
 		}
@@ -1210,7 +1210,7 @@ static size_t _rr_uncompressed_rdata_size(_getdns_rrtype_iter *rr)
 static size_t _rr_rdata_size(_getdns_rrtype_iter *rr)
 {
 	const _getdns_rr_def *rr_def;
-	size_t i;
+	int i;
 
 	rr_def = _getdns_rr_def_lookup(gldns_read_uint16(rr->rr_i.rr_type));
 
@@ -1626,7 +1626,7 @@ static int nsec3_iteration_count_high(_getdns_rrtype_iter *dnskey, _getdns_rrset
 		return gldns_read_uint16(rr->rr_i.rr_type + 12) > 150;
 }
 
-static int check_dates(int32_t now, int32_t skew, int32_t exp, int32_t inc)
+static int check_dates(time_t now, int32_t skew, int32_t exp, int32_t inc)
 {
 	return (exp - inc > 0) && (inc - now < skew) && (now - exp < skew);
 }

--- a/src/general.c
+++ b/src/general.c
@@ -420,7 +420,7 @@ getdns_general_ns(getdns_context *context, getdns_eventloop *loop,
 	getdns_network_req *netreq, **netreq_p;
 	getdns_dns_req *req;
 	getdns_dict *localnames_response;
-	size_t i;
+	int i;
 
 	if (!context || !name || (!callbackfn && !internal_cb))
 		return GETDNS_RETURN_INVALID_PARAMETER;

--- a/src/list.c
+++ b/src/list.c
@@ -312,7 +312,7 @@ getdns_return_t
 _getdns_list_copy(const struct getdns_list * srclist,
 	struct getdns_list ** dstlist)
 {
-	int i;
+	unsigned int i;
 	getdns_return_t retval;
 
 	if (!dstlist)

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -260,10 +260,10 @@ _getdns_network_req_clear_upstream_options(getdns_network_req * req)
 {
   size_t pktlen;
   if (req->opt) {
-	  gldns_write_uint16(req->opt + 9, req->base_query_option_sz);
+	  gldns_write_uint16(req->opt + 9, (uint16_t) req->base_query_option_sz);
 	  req->response = req->opt + 11 + req->base_query_option_sz;
 	  pktlen = req->response - req->query;
-	  gldns_write_uint16(req->query - 2, pktlen);
+	  gldns_write_uint16(req->query - 2, (uint16_t) pktlen);
   }
 }
 
@@ -426,7 +426,7 @@ _getdns_network_req_add_tsig(getdns_network_req *req)
 	gldns_buffer_write_u16(&gbuf, GETDNS_RRCLASS_ANY);	/* Class */
 	gldns_buffer_write_u32(&gbuf, 0);			/* TTL */
 	gldns_buffer_write_u16(&gbuf,
-	    tsig_info->dname_len + 10 + md_len + 6);	/* RdLen */
+	    (uint16_t)(tsig_info->dname_len + 10 + md_len + 6));	/* RdLen */
 	gldns_buffer_write(&gbuf,
 	    tsig_info->dname, tsig_info->dname_len);	/* Algorithm Name */
 	gldns_buffer_write_u48(&gbuf, time(NULL));	/* Time Signed */
@@ -563,7 +563,7 @@ _getdns_network_validate_tsig(getdns_network_req *req)
 		return;
 
 	gldns_buffer_write_u16(&gbuf, 0);		/* Other len */
-	other_len = gldns_read_uint16(rdf->pos);
+	other_len = (uint8_t) gldns_read_uint16(rdf->pos);
 	if (other_len != rdf->nxt - rdf->pos - 2)
 		return;
 	if (other_len)
@@ -921,7 +921,7 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 	    request_type, dnssec_extension_set, with_opt,
 	    edns_maximum_udp_payload_size,
 	    edns_extended_rcode, edns_version, edns_do_bit,
-	    opt_options_size, noptions, options,
+	    (uint16_t) opt_options_size, noptions, options,
 	    netreq_sz - sizeof(getdns_network_req), max_query_sz,
 	    extensions);
 
@@ -932,7 +932,7 @@ _getdns_dns_req_new(getdns_context *context, getdns_eventloop *loop,
 		    dnssec_extension_set, with_opt,
 		    edns_maximum_udp_payload_size,
 		    edns_extended_rcode, edns_version, edns_do_bit,
-		    opt_options_size, noptions, options,
+		    (uint16_t) opt_options_size, noptions, options,
 		    netreq_sz - sizeof(getdns_network_req), max_query_sz,
 		    extensions);
 

--- a/src/rr-dict.c
+++ b/src/rr-dict.c
@@ -429,7 +429,7 @@ hip_hit_2wire(
 		return GETDNS_RETURN_NEED_MORE_SPACE;
 	}
 	*rdf_len = value->size;
-	rdata[0] = value->size;
+	rdata[0] = (uint8_t) value->size;
 	(void)memcpy(rdf, value->data, value->size);
 	return GETDNS_RETURN_GOOD;
 }
@@ -501,7 +501,7 @@ hip_public_key_2wire(
 		return GETDNS_RETURN_NEED_MORE_SPACE;
 	}
 	*rdf_len = value->size;
-	gldns_write_uint16(rdata + 2, value->size);
+	gldns_write_uint16(rdata + 2, (uint16_t) value->size);
 	(void)memcpy(rdf, value->data, value->size);
 	return GETDNS_RETURN_GOOD;
 }

--- a/src/rr-iter.c
+++ b/src/rr-iter.c
@@ -75,8 +75,8 @@ find_rrtype(_getdns_rr_iter *i)
 
 	/* Past the last RR in the pkt */
 	if (i->pkt &&
-	    GLDNS_QDCOUNT(i->pkt) + GLDNS_ANCOUNT(i->pkt) +
-	    GLDNS_NSCOUNT(i->pkt) + GLDNS_ARCOUNT(i->pkt) <= i->n)
+	    (unsigned)(GLDNS_QDCOUNT(i->pkt) + GLDNS_ANCOUNT(i->pkt) +
+	               GLDNS_NSCOUNT(i->pkt) + GLDNS_ARCOUNT(i->pkt)) <= i->n)
 		goto done;
 
 	for (pos = i->pos; pos + 4 < i->pkt_end; pos += *pos + 1)
@@ -101,7 +101,7 @@ done:
 }
 
 _getdns_rr_iter *
-_getdns_rr_iter_init(_getdns_rr_iter *i, const uint8_t *pkt, size_t pkt_len)
+_getdns_rr_iter_init(_getdns_rr_iter *i, const uint8_t *pkt, const size_t pkt_len)
 {
 	assert(i);
 
@@ -119,7 +119,7 @@ _getdns_rr_iter_init(_getdns_rr_iter *i, const uint8_t *pkt, size_t pkt_len)
 
 _getdns_rr_iter *
 _getdns_single_rr_iter_init(
-    _getdns_rr_iter *i, const uint8_t *wire, size_t wire_len)
+    _getdns_rr_iter *i, const uint8_t *wire, const size_t wire_len)
 {
 	assert(i);
 

--- a/src/rr-iter.h
+++ b/src/rr-iter.h
@@ -88,16 +88,16 @@ _getdns_rr_iter_section(_getdns_rr_iter *i)
 {
 	return !i->pkt ? (i->nxt - i->rr_type == 4 ? SECTION_QUESTION
 	                                           : SECTION_ANSWER  )
-             : i->n < GLDNS_QDCOUNT(i->pkt) ? SECTION_QUESTION
-	     : i->n < GLDNS_QDCOUNT(i->pkt)
-	            + GLDNS_ANCOUNT(i->pkt) ? SECTION_ANSWER
-	     : i->n < GLDNS_QDCOUNT(i->pkt)
-	            + GLDNS_ANCOUNT(i->pkt)
-	            + GLDNS_NSCOUNT(i->pkt) ? SECTION_AUTHORITY
-	     : i->n < GLDNS_QDCOUNT(i->pkt)
-	            + GLDNS_ANCOUNT(i->pkt)
-	            + GLDNS_NSCOUNT(i->pkt)
-	            + GLDNS_ARCOUNT(i->pkt) ? SECTION_ADDITIONAL
+         : i->n < GLDNS_QDCOUNT(i->pkt) ? SECTION_QUESTION
+	     : i->n < (unsigned)(GLDNS_QDCOUNT(i->pkt)
+	                       + GLDNS_ANCOUNT(i->pkt)) ? SECTION_ANSWER
+	     : i->n < (unsigned)(GLDNS_QDCOUNT(i->pkt)
+	                       + GLDNS_ANCOUNT(i->pkt)
+	                       + GLDNS_NSCOUNT(i->pkt)) ? SECTION_AUTHORITY
+	     : i->n < (unsigned)(GLDNS_QDCOUNT(i->pkt)
+	                       + GLDNS_ANCOUNT(i->pkt)
+	                       + GLDNS_NSCOUNT(i->pkt)
+	                       + GLDNS_ARCOUNT(i->pkt)) ? SECTION_ADDITIONAL
 	                                    : SECTION_ANY;
 }
 

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -890,7 +890,7 @@ static int _srv_cmp(const void *a, const void *b)
 
 static void _rfc2782_sort(_srv_rr *start, _srv_rr *end)
 {
-	int running_sum, n;
+	unsigned int running_sum, n;
 	_srv_rr *i, *j, swap;
 
 	/* First move all SRVs with weight 0 to the beginning of the list */
@@ -1379,7 +1379,8 @@ static void _getdns_reply2wire_buf(gldns_buffer *buf, getdns_dict *reply)
 {
 	getdns_dict *rr_dict, *q_dict, *h_dict;
 	getdns_list *section;
-	size_t i, pkt_start, ancount, nscount;
+	size_t i, pkt_start;
+	uint16_t ancount, nscount;
 	uint32_t qtype, qclass = GETDNS_RRCLASS_IN, rcode = GETDNS_RCODE_NOERROR;
 	getdns_bindata *qname;
 
@@ -1433,7 +1434,8 @@ static void _getdns_reply2wire_buf(gldns_buffer *buf, getdns_dict *reply)
 static void _getdns_list2wire_buf(gldns_buffer *buf, getdns_list *l)
 {
 	getdns_dict *rr_dict;
-	size_t i, pkt_start, ancount;
+	size_t i, pkt_start;
+	uint16_t ancount;
 	uint32_t qtype, qclass = GETDNS_RRCLASS_IN;
 	getdns_bindata *qname;
 


### PR DESCRIPTION
This PR fixes the majority of the compilation warnings for GetDNS on Windows. The fixes are straightforward.

Two sets of warnings are not fixed: the issues in the GLDNS code, which should be fixed by synchronizing with the Unbound code, and the issues related to timeout casting, for which I am really not sure that casting to 32 bits is the right answer.