### PR TITLE
A special bit for the snprintf style modus operandi of fixed gldns gbuffer's

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1101,17 +1101,16 @@ AH_BOTTOM([
 #endif
 
 #ifdef GETDNS_ON_WINDOWS
-/* On windows it is allowed to increase the FD_SETSIZE
- * (and nescessary to make our custom eventloop work)
- * See: https://support.microsoft.com/en-us/kb/111855
- */
-#ifndef FD_SETSIZE
-#define FD_SETSIZE 1024
-#endif
-
-#define PRIsz "%Iu"
+ /* On windows it is allowed to increase the FD_SETSIZE
+  * (and nescessary to make our custom eventloop work)
+  * See: https://support.microsoft.com/en-us/kb/111855
+  */
+# ifndef FD_SETSIZE
+# define FD_SETSIZE 1024
+# endif
+# define PRIsz "%Iu"
 #else
-#define PRIsz "%zu"
+# define PRIsz "%zu"
 #endif
 
 #include <stdint.h>
@@ -1147,8 +1146,6 @@ AH_BOTTOM([
 #else
 #define FD_SET_T 
 #endif
-
-
 
 #ifdef __cplusplus
 extern "C" {
@@ -1202,6 +1199,12 @@ int inet_pton(int af, const char* src, void* dst);
 
 #ifndef HAVE_INET_NTOP
 const char *inet_ntop(int af, const void *src, char *dst, size_t size);
+#endif
+
+#ifdef USE_WINSOCK
+static inline int _gldns_custom_vsnprintf(char *str, size_t size, const char *format, va_list ap)
+{ int r = vsnprintf(str, size, format, ap); return r == -1 ? _vscprintf(format, ap) : r; }
+# define vsnprintf _gldns_custom_vsnprintf
 #endif
 
 #ifdef __cplusplus

--- a/src/context.c
+++ b/src/context.c
@@ -1354,7 +1354,7 @@ getdns_context_create_with_extended_memory_functions(
 	result->suffixes = no_suffixes;
 	result->suffixes_len = sizeof(no_suffixes);
 
-	gldns_buffer_init_frm_data(&gbuf, result->trust_anchors_spc
+	gldns_buffer_init_frm_data_v(&gbuf, result->trust_anchors_spc
 	                                , sizeof(result->trust_anchors_spc));
 
 	if (!_getdns_parse_ta_file(NULL, &gbuf)) {
@@ -2333,7 +2333,7 @@ getdns_context_set_suffix(getdns_context *context, getdns_list *value)
 		context->suffixes_len = sizeof(no_suffixes);
 		return GETDNS_RETURN_GOOD;
 	}
-	gldns_buffer_init_frm_data(&gbuf, buf_spc, sizeof(buf_spc));
+	gldns_buffer_init_frm_data_v(&gbuf, buf_spc, sizeof(buf_spc));
 	for (;;) {
 		for ( i = 0
 		    ; !(r = getdns_list_get_bindata(value, i, &bindata))

--- a/src/context.c
+++ b/src/context.c
@@ -1354,7 +1354,7 @@ getdns_context_create_with_extended_memory_functions(
 	result->suffixes = no_suffixes;
 	result->suffixes_len = sizeof(no_suffixes);
 
-	gldns_buffer_init_frm_data_v(&gbuf, result->trust_anchors_spc
+	gldns_buffer_init_vfixed_frm_data(&gbuf, result->trust_anchors_spc
 	                                , sizeof(result->trust_anchors_spc));
 
 	if (!_getdns_parse_ta_file(NULL, &gbuf)) {
@@ -2333,7 +2333,7 @@ getdns_context_set_suffix(getdns_context *context, getdns_list *value)
 		context->suffixes_len = sizeof(no_suffixes);
 		return GETDNS_RETURN_GOOD;
 	}
-	gldns_buffer_init_frm_data_v(&gbuf, buf_spc, sizeof(buf_spc));
+	gldns_buffer_init_vfixed_frm_data(&gbuf, buf_spc, sizeof(buf_spc));
 	for (;;) {
 		for ( i = 0
 		    ; !(r = getdns_list_get_bindata(value, i, &bindata))

--- a/src/convert.c
+++ b/src/convert.c
@@ -297,7 +297,7 @@ getdns_rr_dict2wire_scan(
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
 
-	gldns_buffer_init_frm_data(&gbuf, *wire, *wire_sz);
+	gldns_buffer_init_frm_data_v(&gbuf, *wire, *wire_sz);
 	if ((r = _getdns_rr_dict2wire(rr_dict, &gbuf)))
 		return r;
 
@@ -447,7 +447,7 @@ getdns_rr_dict2str_scan(
 	if (!rr_dict || !str || !*str || !str_len)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	gldns_buffer_init_frm_data(&gbuf, buf, sizeof(buf_spc));
+	gldns_buffer_init_frm_data_v(&gbuf, buf, sizeof(buf_spc));
 	r = _getdns_rr_dict2wire(rr_dict, &gbuf);
 	if (gldns_buffer_position(&gbuf) > sizeof(buf_spc)) {
 		if (!(buf = GETDNS_XMALLOC(
@@ -960,7 +960,7 @@ getdns_msg_dict2wire_scan(
 	if (!msg_dict || !wire || !wire_sz || (!*wire && *wire_sz))
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	gldns_buffer_init_frm_data(&gbuf, *wire, *wire_sz);
+	gldns_buffer_init_frm_data_v(&gbuf, *wire, *wire_sz);
 	if ((r = _getdns_msg_dict2wire_buf(msg_dict, &gbuf)))
 		return r;
 
@@ -1036,7 +1036,7 @@ getdns_msg_dict2str_scan(
 	if (!msg_dict || !str || !*str || !str_len)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	gldns_buffer_init_frm_data(&gbuf, buf, sizeof(buf_spc));
+	gldns_buffer_init_frm_data_v(&gbuf, buf, sizeof(buf_spc));
 	r = _getdns_msg_dict2wire_buf(msg_dict, &gbuf);
 	if (gldns_buffer_position(&gbuf) > sizeof(buf_spc)) {
 		if (!(buf = GETDNS_XMALLOC(

--- a/src/convert.c
+++ b/src/convert.c
@@ -297,7 +297,7 @@ getdns_rr_dict2wire_scan(
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
 
-	gldns_buffer_init_frm_data_v(&gbuf, *wire, *wire_sz);
+	gldns_buffer_init_vfixed_frm_data(&gbuf, *wire, *wire_sz);
 	if ((r = _getdns_rr_dict2wire(rr_dict, &gbuf)))
 		return r;
 
@@ -447,7 +447,7 @@ getdns_rr_dict2str_scan(
 	if (!rr_dict || !str || !*str || !str_len)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	gldns_buffer_init_frm_data_v(&gbuf, buf, sizeof(buf_spc));
+	gldns_buffer_init_vfixed_frm_data(&gbuf, buf, sizeof(buf_spc));
 	r = _getdns_rr_dict2wire(rr_dict, &gbuf);
 	if (gldns_buffer_position(&gbuf) > sizeof(buf_spc)) {
 		if (!(buf = GETDNS_XMALLOC(
@@ -960,7 +960,7 @@ getdns_msg_dict2wire_scan(
 	if (!msg_dict || !wire || !wire_sz || (!*wire && *wire_sz))
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	gldns_buffer_init_frm_data_v(&gbuf, *wire, *wire_sz);
+	gldns_buffer_init_vfixed_frm_data(&gbuf, *wire, *wire_sz);
 	if ((r = _getdns_msg_dict2wire_buf(msg_dict, &gbuf)))
 		return r;
 
@@ -1036,7 +1036,7 @@ getdns_msg_dict2str_scan(
 	if (!msg_dict || !str || !*str || !str_len)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	gldns_buffer_init_frm_data_v(&gbuf, buf, sizeof(buf_spc));
+	gldns_buffer_init_vfixed_frm_data(&gbuf, buf, sizeof(buf_spc));
 	r = _getdns_msg_dict2wire_buf(msg_dict, &gbuf);
 	if (gldns_buffer_position(&gbuf) > sizeof(buf_spc)) {
 		if (!(buf = GETDNS_XMALLOC(

--- a/src/dict.c
+++ b/src/dict.c
@@ -1186,7 +1186,7 @@ getdns_pretty_snprint_dict(char *str, size_t size, const getdns_dict *dict)
 
 	if (!dict) return -1;
 
-	gldns_buffer_init_frm_data(&buf, str, size);
+	gldns_buffer_init_frm_data_v(&buf, str, size);
 	return getdns_pp_dict(&buf, 0, dict, 0) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }
@@ -1220,7 +1220,7 @@ getdns_pretty_snprint_list(char *str, size_t size, const getdns_list *list)
 
 	if (!list) return -1;
 
-	gldns_buffer_init_frm_data(&buf, str, size);
+	gldns_buffer_init_frm_data_v(&buf, str, size);
 	return getdns_pp_list(&buf, 0, list, 0, 0) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }
@@ -1255,7 +1255,7 @@ getdns_snprint_json_dict(
 
 	if (!dict) return -1;
 
-	gldns_buffer_init_frm_data(&buf, str, size);
+	gldns_buffer_init_frm_data_v(&buf, str, size);
 	return getdns_pp_dict(&buf, 0, dict, pretty ? 1 : 2) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }
@@ -1290,7 +1290,7 @@ getdns_snprint_json_list(
 
 	if (!list) return -1;
 
-	gldns_buffer_init_frm_data(&buf, str, size);
+	gldns_buffer_init_frm_data_v(&buf, str, size);
 	return getdns_pp_list(&buf, 0, list, 0, pretty ? 1 : 2) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }

--- a/src/dict.c
+++ b/src/dict.c
@@ -1186,7 +1186,7 @@ getdns_pretty_snprint_dict(char *str, size_t size, const getdns_dict *dict)
 
 	if (!dict) return -1;
 
-	gldns_buffer_init_frm_data_v(&buf, str, size);
+	gldns_buffer_init_vfixed_frm_data(&buf, str, size);
 	return getdns_pp_dict(&buf, 0, dict, 0) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }
@@ -1220,7 +1220,7 @@ getdns_pretty_snprint_list(char *str, size_t size, const getdns_list *list)
 
 	if (!list) return -1;
 
-	gldns_buffer_init_frm_data_v(&buf, str, size);
+	gldns_buffer_init_vfixed_frm_data(&buf, str, size);
 	return getdns_pp_list(&buf, 0, list, 0, 0) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }
@@ -1255,7 +1255,7 @@ getdns_snprint_json_dict(
 
 	if (!dict) return -1;
 
-	gldns_buffer_init_frm_data_v(&buf, str, size);
+	gldns_buffer_init_vfixed_frm_data(&buf, str, size);
 	return getdns_pp_dict(&buf, 0, dict, pretty ? 1 : 2) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }
@@ -1290,7 +1290,7 @@ getdns_snprint_json_list(
 
 	if (!list) return -1;
 
-	gldns_buffer_init_frm_data_v(&buf, str, size);
+	gldns_buffer_init_vfixed_frm_data(&buf, str, size);
 	return getdns_pp_list(&buf, 0, list, 0, pretty ? 1 : 2) < 0
 	     ? -1 : (int)gldns_buffer_position(&buf);
 }

--- a/src/gldns/gbuffer.c
+++ b/src/gldns/gbuffer.c
@@ -133,8 +133,8 @@ gldns_buffer_printf(gldns_buffer *buffer, const char *format, ...)
 
 		remaining = gldns_buffer_remaining(buffer);
 		va_start(args, format);
-		written = _gldns_vsnprintf((char*)gldns_buffer_current(buffer),
-		    remaining, format, args);
+		written = vsnprintf((char *) gldns_buffer_current(buffer), remaining,
+				    format, args);
 		va_end(args);
 		if (written == -1) {
 			buffer->_status_err = 1;
@@ -145,8 +145,7 @@ gldns_buffer_printf(gldns_buffer *buffer, const char *format, ...)
 				return -1;
 			}
 			va_start(args, format);
-			written = _gldns_vsnprintf(
-			    (char *) gldns_buffer_current(buffer),
+			written = vsnprintf((char *) gldns_buffer_current(buffer),
 			    gldns_buffer_remaining(buffer), format, args);
 			va_end(args);
 			if (written == -1) {

--- a/src/gldns/gbuffer.c
+++ b/src/gldns/gbuffer.c
@@ -72,7 +72,7 @@ gldns_buffer_init_frm_data(gldns_buffer *buffer, void *data, size_t size)
 }
 
 void
-gldns_buffer_init_frm_data_v(gldns_buffer *buffer, void *data, size_t size)
+gldns_buffer_init_vfixed_frm_data(gldns_buffer *buffer, void *data, size_t size)
 {
 	memset(buffer, 0, sizeof(*buffer));
 	buffer->_data = data;

--- a/src/gldns/gbuffer.c
+++ b/src/gldns/gbuffer.c
@@ -33,6 +33,7 @@ gldns_buffer_new(size_t capacity)
 	buffer->_position = 0;
 	buffer->_limit = buffer->_capacity = capacity;
 	buffer->_fixed = 0;
+	buffer->_vfixed = 0;
 	buffer->_status_err = 0;
 	
 	gldns_buffer_invariant(buffer);
@@ -48,6 +49,7 @@ gldns_buffer_new_frm_data(gldns_buffer *buffer, void *data, size_t size)
 	buffer->_position = 0; 
 	buffer->_limit = buffer->_capacity = size;
 	buffer->_fixed = 0;
+	buffer->_vfixed = 0;
 	buffer->_data = malloc(size);
 	if(!buffer->_data) {
 		buffer->_status_err = 1;
@@ -66,6 +68,17 @@ gldns_buffer_init_frm_data(gldns_buffer *buffer, void *data, size_t size)
 	buffer->_data = data;
 	buffer->_capacity = buffer->_limit = size;
 	buffer->_fixed = 1;
+	buffer->_vfixed = 0;
+}
+
+void
+gldns_buffer_init_frm_data_v(gldns_buffer *buffer, void *data, size_t size)
+{
+	memset(buffer, 0, sizeof(*buffer));
+	buffer->_data = data;
+	buffer->_capacity = buffer->_limit = size;
+	buffer->_fixed = 1;
+	buffer->_vfixed = 1;
 }
 
 int
@@ -126,7 +139,7 @@ gldns_buffer_printf(gldns_buffer *buffer, const char *format, ...)
 		if (written == -1) {
 			buffer->_status_err = 1;
 			return -1;
-		} else if (!buffer->_fixed && (size_t) written >= remaining) {
+		} else if (!buffer->_vfixed && (size_t) written >= remaining) {
 			if (!gldns_buffer_reserve(buffer, (size_t) written + 1)) {
 				buffer->_status_err = 1;
 				return -1;

--- a/src/gldns/gbuffer.h
+++ b/src/gldns/gbuffer.h
@@ -194,14 +194,16 @@ void gldns_buffer_init_frm_data(gldns_buffer *buffer, void *data, size_t size);
 
 /**
  * Setup a buffer with the data pointed to. No data copied, no memory allocs.
- * The buffer is fixed.  Writes beyond size (the capacity) will update the 
- * position (and not write data).  This allows to determine how big the buffer
- * should have been to contain all the written data.
+ * The buffer is "virtually" fixed.  Writes beyond size (the capacity) will
+ * only update position, but no data will be written beyond capacity.  This
+ * allows to determine how big the buffer should have been to contain all the
+ * written data, by looking at the position with gldns_buffer_position(),
+ * similarly to the return value of POSIX's snprintf.
  * \param[in] buffer pointer to the buffer to put the data in
  * \param[in] data the data to encapsulate in the buffer
  * \param[in] size the size of the data
  */
-void gldns_buffer_init_frm_data_v(gldns_buffer *buffer, void *data, size_t size);
+void gldns_buffer_init_vfixed_frm_data(gldns_buffer *buffer, void *data, size_t size);
 
 /**
  * clears the buffer and make it ready for writing.  The buffer's limit

--- a/src/gldns/gbuffer.h
+++ b/src/gldns/gbuffer.h
@@ -27,21 +27,6 @@ extern "C" {
 #  endif
 #endif
 
-#ifndef USE_WINSOCK
-#define _gldns_vsnprintf vsnprintf
-#else
-/* Unlike Linux and BSD, vsnprintf on Windows returns -1 on overflow.
- * Here it is redefined to always return the amount printed
- * if enough space had been available.
- */
-INLINE int
-_gldns_vsnprintf(char *str, size_t size, const char *format, va_list ap)
-{
-	int r = vsnprintf(str, size, format, ap);
-	return r == -1 ? _vscprintf(format, ap) : r;
-}
-#endif
-
 /*
  * Copy data allowing for unaligned accesses in network byte order
  * (big endian).
@@ -175,7 +160,7 @@ gldns_buffer_invariant(gldns_buffer *buffer)
 	assert(buffer != NULL);
 	assert(buffer->_position <= buffer->_limit || buffer->_vfixed);
 	assert(buffer->_limit <= buffer->_capacity);
-	assert(buffer->_data != NULL || (buffer->_capacity == 0 && buffer->_vfixed));
+	assert(buffer->_data != NULL || (buffer->_vfixed && buffer->_capacity == 0));
 }
 #endif
 
@@ -210,7 +195,7 @@ void gldns_buffer_init_frm_data(gldns_buffer *buffer, void *data, size_t size);
 /**
  * Setup a buffer with the data pointed to. No data copied, no memory allocs.
  * The buffer is fixed.  Writes beyond size (the capacity) will update the 
- * position (and not write data.  This allows to determine how big the buffer
+ * position (and not write data).  This allows to determine how big the buffer
  * should have been to contain all the written data.
  * \param[in] buffer pointer to the buffer to put the data in
  * \param[in] data the data to encapsulate in the buffer

--- a/src/gldns/wire2str.c
+++ b/src/gldns/wire2str.c
@@ -279,7 +279,7 @@ int gldns_wire2str_dname_buf(uint8_t* d, size_t dlen, char* s, size_t slen)
 
 int gldns_str_vprint(char** str, size_t* slen, const char* format, va_list args)
 {
-	int w = _gldns_vsnprintf(*str, *slen, format, args);
+	int w = vsnprintf(*str, *slen, format, args);
 	if(w < 0) {
 		/* error in printout */
 		return 0;

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -383,7 +383,7 @@ _getdns_network_req_add_tsig(getdns_network_req *req)
 #endif
 	tsig_info = _getdns_get_tsig_info(upstream->tsig_alg);
 
-	gldns_buffer_init_frm_data(&gbuf, req->response, MAXIMUM_TSIG_SPACE);
+	gldns_buffer_init_frm_data_v(&gbuf, req->response, MAXIMUM_TSIG_SPACE);
 	gldns_buffer_write(&gbuf,
 	    upstream->tsig_dname, upstream->tsig_dname_len);	/* Name */
 	gldns_buffer_write_u16(&gbuf, GETDNS_RRCLASS_ANY);	/* Class */

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -383,7 +383,7 @@ _getdns_network_req_add_tsig(getdns_network_req *req)
 #endif
 	tsig_info = _getdns_get_tsig_info(upstream->tsig_alg);
 
-	gldns_buffer_init_frm_data_v(&gbuf, req->response, MAXIMUM_TSIG_SPACE);
+	gldns_buffer_init_vfixed_frm_data(&gbuf, req->response, MAXIMUM_TSIG_SPACE);
 	gldns_buffer_write(&gbuf,
 	    upstream->tsig_dname, upstream->tsig_dname_len);	/* Name */
 	gldns_buffer_write_u16(&gbuf, GETDNS_RRCLASS_ANY);	/* Class */

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -1510,7 +1510,7 @@ uint8_t *_getdns_list2wire(
 	gldns_buffer gbuf;
 	size_t sz;
 
-	gldns_buffer_init_frm_data_v(&gbuf, buf, *buf_len);
+	gldns_buffer_init_vfixed_frm_data(&gbuf, buf, *buf_len);
 	_getdns_list2wire_buf(&gbuf, l);
 
 	if ((sz = gldns_buffer_position(&gbuf)) <= *buf_len) {
@@ -1531,7 +1531,7 @@ uint8_t *_getdns_reply2wire(
 	gldns_buffer gbuf;
 	size_t sz;
 
-	gldns_buffer_init_frm_data_v(&gbuf, buf, *buf_len);
+	gldns_buffer_init_vfixed_frm_data(&gbuf, buf, *buf_len);
 	_getdns_reply2wire_buf(&gbuf, r);
 
 	if ((sz = gldns_buffer_position(&gbuf)) <= *buf_len) {

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -1510,7 +1510,7 @@ uint8_t *_getdns_list2wire(
 	gldns_buffer gbuf;
 	size_t sz;
 
-	gldns_buffer_init_frm_data(&gbuf, buf, *buf_len);
+	gldns_buffer_init_frm_data_v(&gbuf, buf, *buf_len);
 	_getdns_list2wire_buf(&gbuf, l);
 
 	if ((sz = gldns_buffer_position(&gbuf)) <= *buf_len) {
@@ -1531,7 +1531,7 @@ uint8_t *_getdns_reply2wire(
 	gldns_buffer gbuf;
 	size_t sz;
 
-	gldns_buffer_init_frm_data(&gbuf, buf, *buf_len);
+	gldns_buffer_init_frm_data_v(&gbuf, buf, *buf_len);
 	_getdns_reply2wire_buf(&gbuf, r);
 
 	if ((sz = gldns_buffer_position(&gbuf)) <= *buf_len) {


### PR DESCRIPTION
Wouter requested to have this modus operandi explicitly specified before synchronizing gldns with sldns, because unbound relies on the previous behaviour of fixed size gbuffers.