### PR TITLE
Implement sensible default padding policy.

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -1435,7 +1435,7 @@ getdns_context_create_with_extended_memory_functions(
 	result->edns_version = 0;
 	result->edns_do_bit = 0;
 	result->edns_client_subnet_private = 0;
-	result->tls_query_padding_blocksize = 1; /* default is to not try to pad */
+	result->tls_query_padding_blocksize = 1; /* default is to pad queries sensibly */
 	result->tls_ctx = NULL;
 
 	result->extension = &result->default_eventloop.loop;

--- a/src/stub.c
+++ b/src/stub.c
@@ -1284,12 +1284,15 @@ stub_tls_write(getdns_upstream *upstream, getdns_tcp_state *tcp,
 					return STUB_OUT_OF_OPTIONS;
 				netreq->keepalive_sent = 1;
 			}
-			if (netreq->owner->tls_query_padding_blocksize > 1) {
+			if (netreq->owner->tls_query_padding_blocksize > 0) {
+				uint16_t blksz = netreq->owner->tls_query_padding_blocksize;
+				if (blksz == 1) /* use a sensible default policy */
+					blksz = 128;
 				pkt_len = netreq->response - netreq->query;
 				pkt_len += 4; /* this accounts for the OPTION-CODE and OPTION-LENGTH of the padding */
-				padding_sz = pkt_len % netreq->owner->tls_query_padding_blocksize;
+				padding_sz = pkt_len % blksz;
 				if (padding_sz)
-					padding_sz = netreq->owner->tls_query_padding_blocksize - padding_sz;
+					padding_sz = blksz - padding_sz;
 				if (_getdns_network_req_add_upstream_option(netreq,
 									    EDNS_PADDING_OPCODE,
 									    padding_sz, NULL))

--- a/src/tools/getdns_query.c
+++ b/src/tools/getdns_query.c
@@ -54,7 +54,7 @@ static const char *default_stubby_config =
 ", dns_transport_list: [ GETDNS_TRANSPORT_TLS, GETDNS_TRANSPORT_UDP, GETDNS_TRANSPORT_TCP ]"
 ", idle_timeout: 10000"
 ", listen_addresses: [ 127.0.0.1@53, 0::1@53 ]"
-", tls_query_padding_blocksize: 256"
+", tls_query_padding_blocksize: 1"
 ", edns_client_subnet_private : 1"
 "}";
 static int clear_listen_list_on_arg = 0;
@@ -243,7 +243,8 @@ print_usage(FILE *out, const char *progname)
 	fprintf(out, "\t-n\tSet TLS authentication mode to NONE (default)\n");
 	fprintf(out, "\t-m\tSet TLS authentication mode to REQUIRED\n");
 	fprintf(out, "\t-p\tPretty print response dict\n");
-	fprintf(out, "\t-P <blocksize>\tPad TLS queries to a multiple of blocksize\n");
+	fprintf(out, "\t-P <blocksize>\tPad TLS queries to a multiple of blocksize\n"
+		"\t\t(special values: 0: no padding, 1: sensible default policy)\n");
 	fprintf(out, "\t-q\tQuiet mode - don't print response\n");
 	fprintf( out, "\t-r\tSet recursing resolution type%s\n"
 	       , i_am_stubby ? "(default = stub)" : "");


### PR DESCRIPTION
This commit changes the semantics of tls_query_padding_blocksize()
slightly.  Where previously both 0 and 1 meant "no padding", this
commit changes 1 to mean "pad using a sensible policy".

At NDSS 2017's DNS privacy workshop, I presented an empirical study of
DNS padding policies:

https://www.internetsociety.org/events/ndss-symposium/ndss-symposium-2017/dns-privacy-workshop-2017-programme#session3

The slide deck is here:
https://dns.cmrg.net/ndss2017-dprive-empirical-DNS-traffic-size.pdf

The resulting recommendation from the research is that a simple
padding policy is relatively cheap and still protective of metadata
when DNS traffic is encrypted:

 * queries should be padded to a multiple of 128 octets
 * responses should be padded to a multiple of 468 octets

Since getdns is only currently doing queries over tls, we only have to
implement the first part of this policy :)