### PR TITLE
Provide guidance for integration with systemd

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,16 @@
+Stubby integration with systemd
+===============================
+
+For GNU/Linux operating systems which use systemd as a process
+manager, you might want to run stubby as a system service.
+
+This directory provides recommended systemd unit files.
+
+This setup assumes that there is a system-level user named "stubby"
+which is in group "stubby", and try to limit the privileges of the
+running daemon to that user as closely as possible.
+
+Normally, a downstream distributor will install them as:
+
+    /usr/lib/tmpfiles.d/stubby.conf
+    /lib/systemd/system/stubby.service

--- a/systemd/stubby.conf
+++ b/systemd/stubby.conf
@@ -1,0 +1,2 @@
+# tmpfiles.d (5) for use with stubby.service
+d /run/stubby 0750 root stubby - -

--- a/systemd/stubby.service
+++ b/systemd/stubby.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=stubby DNS resolver
+
+[Service]
+WorkingDirectory=/run/stubby
+ExecStart=/usr/bin/stubby
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+User=stubby
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Stubby needs to be able to bind to privileged ports, but otherwise
shouldn't need root capabilities.

systemd makes it easy to set the minimal capability set while
otherwise launching the daemon as a non-privileged user.

Ship these files upstream for distributors to deploy.