### PR TITLE
Stub fixes

### DIFF
--- a/src/stub.c
+++ b/src/stub.c
@@ -588,6 +588,7 @@ _getdns_cancel_stub_request(getdns_network_req *netreq)
 #else
 		close(netreq->fd);
 #endif
+		netreq->fd = -1;
 	}
 }
 
@@ -606,6 +607,7 @@ stub_timeout_cb(void *userarg)
 #else
 		close(netreq->fd);
 #endif
+		netreq->fd = -1;
 		netreq->upstream->udp_timeouts++;
 		if (netreq->upstream->udp_timeouts % 100 == 0)
 			_getdns_upstream_log(netreq->upstream, GETDNS_LOG_UPSTREAM_STATS, GETDNS_LOG_DEBUG,
@@ -1413,6 +1415,7 @@ stub_udp_read_cb(void *userarg)
 #else
 			close(netreq->fd);
 #endif
+			netreq->fd = -1;
 			stub_next_upstream(netreq);
 		}
 		netreq->debug_end_time = _getdns_get_time_as_uintt64();
@@ -1435,8 +1438,8 @@ stub_udp_read_cb(void *userarg)
 	closesocket(netreq->fd);
 #else
 	close(netreq->fd);
-	netreq->fd = -1;
 #endif
+	netreq->fd = -1;
 	while (GLDNS_TC_WIRE(netreq->response)) {
 		DEBUG_STUB("%s %-35s: MSG: %p TC bit set in response \n", STUB_DEBUG_READ, 
 		             __FUNC__, (void*)netreq);
@@ -1533,6 +1536,7 @@ stub_udp_write_cb(void *userarg)
 #else
 			close(netreq->fd);
 #endif
+			netreq->fd = -1;
 			stub_next_upstream(netreq);
 		}
 		netreq->debug_end_time = _getdns_get_time_as_uintt64();

--- a/src/stub.c
+++ b/src/stub.c
@@ -1962,7 +1962,7 @@ upstream_select(getdns_network_req *netreq)
 			return &upstreams->upstreams[i];
 		}
 		i+=GETDNS_UPSTREAM_TRANSPORTS;
-		if (i > upstreams->count)
+		if (i >= upstreams->count)
 			i = 0;
 	} while (i != upstreams->current_udp);
 


### PR DESCRIPTION
This PR fixes a crash bug (array out of bounds trashing the heap) and a subtle error causing getdns to close sockets that don't belong to it. They fix the issues reported in issue #320 

Both of these are pretty high-priority fixes, at least for me, as we have customers using the getdns libraries (as part of powerdns/weakforced), and they found the issues. I just switched to building packages based on the current (1.1.2) release, but I'll have to switch back to building from my own fork until this makes it into a release.