### PR TITLE
Remove mention of using the second bit in set_from_os to init OpenSSL…

### DIFF
--- a/src/getdns/getdns.h.in
+++ b/src/getdns/getdns.h.in
@@ -1101,7 +1101,6 @@ getdns_service(getdns_context *context,
  * (e.g. CRYPTO_THREADID_set_call) depending on the library version used.
  * @param context context that can be used immediately with other API calls
  * @param set_from_os set to 1 to initialize the context with os defaults
- *                    the second bit set (2) prevents OpenSSL library initialization.
  * @return GETDNS_RETURN_GOOD on success
 */
 getdns_return_t
@@ -1114,7 +1113,6 @@ getdns_context_create(getdns_context ** context, int set_from_os);
  * (e.g. CRYPTO_THREADID_set_call) depending on the library version used.
  * @param context context that can be used immediately with other API calls
  * @param set_from_os set to 1 to initialize the context with os defaults
- *                    the second bit set (2) prevents OpenSSL library initialization.
  * @param malloc custom malloc function
  * @param realloc custom realloc function
  * @param free custom free function
@@ -1136,7 +1134,6 @@ getdns_context_create_with_memory_functions(
  * (e.g. CRYPTO_THREADID_set_call) depending on the library version used.
  * @param context context that can be used immediately with other API calls
  * @param set_from_os set to 1 to initialize the context with os defaults
- *                    the second bit set (2) prevents OpenSSL library initialization.
  * @param userarg parameter passed to the custom malloc, realloc and free functions
  * @param malloc custom malloc function
  * @param realloc custom realloc function


### PR DESCRIPTION
… as this no longer applies