### PR TITLE
Minor updates on return_call_reporting. Fix the name in the API spec …

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ The following minor implementation omissions are noted:
 Recursive mode does not support:
 * TLS as a transport
 * Non-zero connection idle timeouts or query pipelining
+* Anything other than query_type and resolution_type in the return_call_reporting extension
 
 Stub mode does not support:
 * Non zero idle timeouts for synchronous calls
-* Limit on number of outstanding queries
 
 # Known Issues
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -875,7 +875,7 @@ names:</p>
 <li><code>query_name</code> (a bindata) is the name that was sent</li>
 <li><code>query_type</code> (an int) is the type that was queried for</li>
 <li><code>query_to</code> (a bindata) is the address to which the query was sent</li>
-<li><code>run_time</code> (a bindata) is the difference between the time the successful
+<li><code>run_time/ms</code> (a bindata) is the difference between the time the successful
 query started and ended in milliseconds, represented
 as a uint32_t (this does not include time taken for connection set up
 or transport fallback)</li>


### PR DESCRIPTION
…and add a know issue that it isn’t fully supported in recursive mode.

Also remove known issue that stub doesn’t limit in outstanding queries as this is now supported.