### PR TITLE
Fix issue on macOX 10.10 where TCP fast open is detected but not impl…

### DIFF
--- a/src/stub.c
+++ b/src/stub.c
@@ -425,15 +425,14 @@ tcp_connect(getdns_upstream *upstream, getdns_transport_list_t transport)
 	endpoints.sae_srcaddrlen = 0;
 	endpoints.sae_dstaddr = (struct sockaddr *)&upstream->addr;
 	endpoints.sae_dstaddrlen = upstream->addr_len;
-	if (connectx(fd, &endpoints, SAE_ASSOCID_ANY,  
+	if (connectx(fd, &endpoints, SAE_ASSOCID_ANY,
 	             CONNECT_DATA_IDEMPOTENT | CONNECT_RESUME_ON_READ_WRITE,
-	             NULL, 0, NULL, NULL) == -1) {
-		if (errno != EINPROGRESS) {
-			close(fd);
-			return -1;
-		}
+	             NULL, 0, NULL, NULL) == 0) {
+		return fd;
 	}
-	return fd;
+	if (errno == EINPROGRESS) {
+		return fd;
+	}
 #else
 	(void)transport;
 #endif


### PR DESCRIPTION
…emented causing TCP to fail. The fix allows fallback to regular TCP in this case and is also more robust for cases where connectx() fails for some reason.

This has been tested on 10.12 both with and without TCP fastopen enabled. 