### PR TITLE
First pass at fixing problems when connections to servers are lost.

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -470,4 +470,6 @@ void _getdns_upstreams_dereference(getdns_upstreams *upstreams);
 
 void _getdns_upstream_shutdown(getdns_upstream *upstream);
 
+void _getdns_upstream_reset(getdns_upstream *upstream);
+
 #endif /* _GETDNS_CONTEXT_H_ */

--- a/src/stub.c
+++ b/src/stub.c
@@ -676,6 +676,7 @@ upstream_setup_timeout_cb(void *userarg)
 		while (upstream->write_queue)
 			upstream_write_cb(upstream);
 	}
+	_getdns_upstream_reset(upstream);
 }
 
 
@@ -1598,6 +1599,8 @@ upstream_read_cb(void *userarg)
 	case STUB_SETUP_ERROR:  /* Can happen for TLS HS*/
 	case STUB_TCP_ERROR:
 		upstream_failed(upstream, (q == STUB_TCP_ERROR ? 0:1) );
+		if (!upstream->write_queue)
+			_getdns_upstream_shutdown(upstream);
 		return;
 
 	default:
@@ -1700,7 +1703,9 @@ upstream_write_cb(void *userarg)
 	            __FUNC__, (void*)netreq);
 
 	/* Health checks on current connection */
-	if (upstream->conn_state == GETDNS_CONN_TEARDOWN)
+	if (upstream->conn_state == GETDNS_CONN_TEARDOWN ||
+	    upstream->conn_state == GETDNS_CONN_CLOSED ||  
+	    upstream->fd == -1)
 		q = STUB_CONN_GONE;
 	else if (!upstream_working_ok(upstream))
 		q = STUB_TCP_ERROR;
@@ -1741,6 +1746,8 @@ upstream_write_cb(void *userarg)
 			_getdns_netreq_change_state(netreq, NET_REQ_ERRORED);
 			_getdns_check_dns_req_complete(netreq->owner);
 		}
+		if (!upstream->write_queue)
+			_getdns_upstream_shutdown(upstream);
 		return;
 
 	default:
@@ -2001,6 +2008,7 @@ upstream_connect(getdns_upstream *upstream, getdns_transport_list_t transport,
 		fd = tcp_connect(upstream, transport);
 		if (fd == -1) {
 			upstream_failed(upstream, 1);
+			_getdns_upstream_reset(upstream);
 			return -1;
 		}
 		upstream->loop = dnsreq->loop;
@@ -2010,6 +2018,7 @@ upstream_connect(getdns_upstream *upstream, getdns_transport_list_t transport,
 			upstream->tls_obj = tls_create_object(dnsreq, fd, upstream);
 			if (upstream->tls_obj == NULL) {
 				upstream_failed(upstream, 1);
+				_getdns_upstream_reset(upstream);
 #ifdef USE_WINSOCK
 				closesocket(fd);
 #else
@@ -2021,7 +2030,7 @@ upstream_connect(getdns_upstream *upstream, getdns_transport_list_t transport,
 		}
 		upstream->conn_state = GETDNS_CONN_SETUP;
 		_getdns_upstream_log(upstream, GETDNS_LOG_UPSTREAM_STATS, GETDNS_LOG_DEBUG,
-		    "%-40s : Conn init     : Transport=%s - Profile=%s\n", 
+		    "%-40s : Conn opened: %s - %s Profile\n", 
 		    upstream->addr_str, transport == GETDNS_TRANSPORT_TLS ? "TLS":"TCP",
 		dnsreq->context->tls_auth_min == GETDNS_AUTHENTICATION_NONE ? "Opportunistic":"Strict");
 		break;

--- a/src/tools/getdns_query.c
+++ b/src/tools/getdns_query.c
@@ -1769,6 +1769,7 @@ main(int argc, char **argv)
 		loop->vmt->run(loop);
 	}
 	else if (listen_count) {
+		fprintf(stderr, "Starting Stubby DAEMON....\n");
 		assert(loop);
 #ifndef GETDNS_ON_WINDOWS
 		if (i_am_stubby && !run_in_foreground) {


### PR DESCRIPTION
Need to reset connection state if connections fail at setup and on read/write if there are no more messages queued.
This means we will back-off servers that fail, so we should think about using a shorter backoff default in stubby
because otherwise temporarily loss of the network connection will mean having to restart stubby.
Also some minor changes to logging.