### PR TITLE
Fix capturing exit code of a test.

### DIFF
--- a/src/test/tpkg/tpkg
+++ b/src/test/tpkg/tpkg
@@ -858,9 +858,10 @@ echo "--------------- Test Output ------------------" | write_result result.$dsc
 pre
 
 out "[log] Executing test" 
-
-( ${SHELL} $dsc_test ${TPKG_ARGS} 2>&1 ) | write_result result.$dsc_basename
+( ${SHELL} $dsc_test ${TPKG_ARGS} 2>&1 ) > result.$dsc_basename.tmp
 test_result=$?
+write_result result.$dsc_basename < result.$dsc_basename.tmp
+rm -f result.$dsc_basename.tmp
 epoch   # would like to run after post, but that is not possible :-(
 if [ $test_result -ne 0 ]; then
         err "[warning] Test executed with errors: $test_result." 


### PR DESCRIPTION
tpkg was not capturing the exit code of the test, but the exit code of the write_result actions.