### PR TITLE
Fix Stubby stopping listening to UDP on Win10 mingw64 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -589,7 +589,7 @@ case "$enable_ed25519" in
     no)
       ;;
     *)
-      if test $USE_NSS = "no" -a $USE_NETTLE = "no"; then
+      if test "$USE_NSS" = "no" -a "$USE_NETTLE" = "no"; then
               AC_CHECK_DECLS([NID_ED25519], [
                 AC_DEFINE_UNQUOTED([USE_ED25519], [1], [Define this to enable ED25519 support.])
                 use_ed25519="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -1274,7 +1274,7 @@ CFLAGS="$CFLAGS $LIBBSD_CFLAGS"
 ],[
 AC_MSG_WARN([libbsd not found or usable; using embedded code instead])
 ])
-AC_CHECK_DECLS([strlcpy,arc4random,arc4random_uniform])
+AC_CHECK_DECLS([inet_pton,inet_ntop,strlcpy,arc4random,arc4random_uniform])
 AC_REPLACE_FUNCS(inet_pton)
 AC_REPLACE_FUNCS(inet_ntop)
 AC_REPLACE_FUNCS(strlcpy)
@@ -1449,11 +1449,11 @@ void SHA512_Final(uint8_t[SHA512_DIGEST_LENGTH], SHA512_CTX*);
 unsigned char *SHA512(void* data, unsigned int data_len, unsigned char *digest);
 #endif /* COMPAT_SHA512 */
 
-#ifndef HAVE_INET_PTON
+#ifndef HAVE_DECL_INET_PTON
 int inet_pton(int af, const char* src, void* dst);
 #endif /* HAVE_INET_PTON */
 
-#ifndef HAVE_INET_NTOP
+#ifndef HAVE_DECL_INET_NTOP
 const char *inet_ntop(int af, const void *src, char *dst, size_t size);
 #endif
 

--- a/src/anchor.c
+++ b/src/anchor.c
@@ -1198,7 +1198,7 @@ static void tas_read_cb(void *userarg)
 				return;
 			}
 		}
-	} else if (_getdns_EWOULDBLOCK)
+	} else if (_getdns_socketerror() == _getdns_EWOULDBLOCK)
 		return;
 
 	DEBUG_ANCHOR("Read error: %d %s\n", (int)n, strerror(errno));
@@ -1248,7 +1248,7 @@ static void tas_write_cb(void *userarg)
 		    tas_read_cb, NULL, tas_timeout_cb));
 		return;
 
-	} else if (_getdns_EWOULDBLOCK || _getdns_EINPROGRESS)
+	} else if (_getdns_socketerror() == _getdns_EWOULDBLOCK || _getdns_socketerror() == _getdns_EINPROGRESS)
 		return;
 
 	DEBUG_ANCHOR("Write error: %s\n", strerror(errno));
@@ -1348,8 +1348,8 @@ static void tas_connect(getdns_context *context, tas_connection *a)
 		addr.sin6_scope_id = 0;
 		r = connect(a->fd, (struct sockaddr *)&addr, sizeof(addr));
 	}
-	if (r == 0 || (r == -1 && (_getdns_EINPROGRESS ||
-	                           _getdns_EWOULDBLOCK))) {
+	if (r == 0 || (r == -1 && (_getdns_socketerror() == _getdns_EINPROGRESS ||
+	                           _getdns_socketerror() == _getdns_EWOULDBLOCK))) {
 		char tas_hostname[256];
 		const char *path = "", *fmt;
 		getdns_return_t R;

--- a/src/anchor.c
+++ b/src/anchor.c
@@ -50,6 +50,7 @@
 #include "gldns/keyraw.h"
 #include "general.h"
 #include "util-internal.h"
+#include "platform.h"
 
 /* get key usage out of its extension, returns 0 if no key_usage extension */
 static unsigned long

--- a/src/context.c
+++ b/src/context.c
@@ -704,11 +704,7 @@ _getdns_upstreams_dereference(getdns_upstreams *upstreams)
 		}
 		if (upstream->fd != -1)
 		{
-#ifdef USE_WINSOCK
-			closesocket(upstream->fd);
-#else
-			close(upstream->fd);
-#endif
+			_getdns_closesocket(upstream->fd);
 		}
 		while (pin) {
 			sha256_pin_t *nextpin = pin->next;
@@ -809,11 +805,7 @@ _getdns_upstream_reset(getdns_upstream *upstream)
 		upstream->tls_obj = NULL;
 	}
 	if (upstream->fd != -1) {
-#ifdef USE_WINSOCK
-		closesocket(upstream->fd);
-#else
-		close(upstream->fd);
-#endif
+		_getdns_closesocket(upstream->fd);
 		upstream->fd = -1;
 	}
 	/* Set connection ready for use again*/

--- a/src/context.c
+++ b/src/context.c
@@ -80,6 +80,7 @@ typedef unsigned short in_port_t;
 #include "context.h"
 #include "types-internal.h"
 #include "util-internal.h"
+#include "platform.h"
 #include "dnssec.h"
 #include "stub.h"
 #include "list.h"

--- a/src/extension/poll_eventloop.c
+++ b/src/extension/poll_eventloop.c
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #include "util-internal.h"
+#include "platform.h"
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif

--- a/src/extension/poll_eventloop.c
+++ b/src/extension/poll_eventloop.c
@@ -27,13 +27,7 @@
 
 #include "config.h"
 
-#ifdef HAVE_SYS_POLL_H
-#include <sys/poll.h>
-#else
-#ifndef USE_WINSOCK
-#include <poll.h>
-#endif
-#endif
+#include "util-internal.h"
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
@@ -411,10 +405,8 @@ poll_eventloop_run_once(getdns_eventloop *loop, int blocking)
     {
         Sleep(poll_timeout);
     } else
-	if (WSAPoll(poll_loop->pfds, poll_loop->fd_events_free, poll_timeout) < 0) {
-#else	
-	if (poll(poll_loop->pfds, poll_loop->fd_events_free, poll_timeout) < 0) {
 #endif
+	if (poll(poll_loop->pfds, poll_loop->fd_events_free, poll_timeout) < 0) {
 		perror("poll() failed");
 		exit(EXIT_FAILURE);
 	}

--- a/src/extension/poll_eventloop.c
+++ b/src/extension/poll_eventloop.c
@@ -407,7 +407,7 @@ poll_eventloop_run_once(getdns_eventloop *loop, int blocking)
         Sleep(poll_timeout);
     } else
 #endif
-	if (poll(poll_loop->pfds, poll_loop->fd_events_free, poll_timeout) < 0) {
+	if (_getdns_poll(poll_loop->pfds, poll_loop->fd_events_free, poll_timeout) < 0) {
 		perror("poll() failed");
 		exit(EXIT_FAILURE);
 	}

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -1131,7 +1131,7 @@ mdns_udp_multicast_read_cb(void *userarg)
 
 
 	if (read == -1 && (_getdns_socketerror() == _getdns_EWOULDBLOCK ||
-		           _getdns_socketerror() == _getdns_ECONNRESET)
+		           _getdns_socketerror() == _getdns_ECONNRESET))
 		return; /* TODO: this will stop the receive loop! */
 
 	if (read >= GLDNS_HEADER_SIZE)
@@ -1705,7 +1705,7 @@ mdns_udp_read_cb(void *userarg)
 										  */
 		0, NULL, NULL);
 	if (read == -1 && (_getdns_socketerror() == _getdns_EWOULDBLOCK ||
-		           _getdns_socketerror() == _getdns_ECONNRESET)
+		           _getdns_socketerror() == _getdns_ECONNRESET))
 		return;
 
 	if (read < GLDNS_HEADER_SIZE)

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -26,6 +26,7 @@
 #include "gldns/pkthdr.h"
 #include "gldns/rrdef.h"
 #include "util-internal.h"
+#include "platform.h"
 #include "mdns.h"
 
 #ifdef HAVE_MDNS_SUPPORT

--- a/src/mdns.h
+++ b/src/mdns.h
@@ -25,6 +25,7 @@
 #include "getdns/getdns.h"
 #include "types-internal.h"
 #include "util-internal.h"
+#include "platform.h"
 #include "util/lruhash.h"
 #include "config.h"
 

--- a/src/mdns.h
+++ b/src/mdns.h
@@ -24,12 +24,9 @@
 #ifdef HAVE_MDNS_SUPPORT
 #include "getdns/getdns.h"
 #include "types-internal.h"
+#include "util-internal.h"
 #include "util/lruhash.h"
 #include "config.h"
-
-#ifndef USE_WINSOCK
-#define SOCKADDR_STORAGE struct sockaddr_storage
-#endif
 
 getdns_return_t
 _getdns_submit_mdns_request(getdns_network_req *netreq);

--- a/src/platform.h
+++ b/src/platform.h
@@ -1,0 +1,81 @@
+/**
+ *
+ * /brief general functions with platform-dependent implementations
+ *
+ */
+
+/*
+ * Copyright (c) 2017, NLnet Labs, Sinodun
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the names of the copyright holders nor the
+ *   names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Verisign, Inc. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+#include "config.h"
+
+#ifdef USE_WINSOCK
+typedef u_short sa_family_t;
+#define _getdns_EAGAIN      (WSATRY_AGAIN)
+#define _getdns_EWOULDBLOCK (WSAEWOULDBLOCK)
+#define _getdns_EINPROGRESS (WSAEINPROGRESS)
+#define _getdns_EMFILE      (WSAEMFILE)
+#define _getdns_ECONNRESET  (WSAECONNRESET)
+
+#define _getdns_closesocket(fd) closesocket(fd)
+#define _getdns_poll(fdarray, nsockets, timer) WSAPoll(fdarray, nsockets, timer)
+#define _getdns_socketerror() (WSAGetLastError())
+
+#else /* USE_WINSOCK */
+
+#ifdef HAVE_SYS_POLL_H
+# include <sys/poll.h>
+#else
+# include <poll.h>
+#endif
+
+#define _getdns_EAGAIN      (EAGAIN)
+#define _getdns_EWOULDBLOCK (EWOULDBLOCK)
+#define _getdns_EINPROGRESS (EINPROGRESS)
+#define _getdns_EMFILE      (EMFILE)
+#define _getdns_ECONNRESET  (ECONNRESET)
+
+#define SOCKADDR struct sockaddr
+#define SOCKADDR_IN struct sockaddr_in
+#define SOCKADDR_IN6 struct sockaddr_in6
+#define SOCKADDR_STORAGE struct sockaddr_storage
+#define SOCKET int
+
+#define IP_MREQ struct ip_mreq
+#define IPV6_MREQ struct ipv6_mreq
+#define BOOL int
+#define TRUE 1
+
+#define _getdns_closesocket(fd) close(fd)
+#define _getdns_poll(fdarray, nsockets, timer) poll(fdarray, nsockets, timer)
+#define _getdns_socketerror() (errno)
+#endif
+
+#endif

--- a/src/server.c
+++ b/src/server.c
@@ -40,6 +40,7 @@
 #include "debug.h"
 #include "util/rbtree.h"
 #include "util-internal.h"
+#include "platform.h"
 #include "server.h"
 
 #define DNS_REQUEST_SZ          4096

--- a/src/server.c
+++ b/src/server.c
@@ -544,6 +544,14 @@ static void udp_read_cb(void *userarg)
 	conn->addrlen = sizeof(conn->remote_in);
 	if ((len = recvfrom(l->fd, (void *)buf, sizeof(buf), 0,
 	    (struct sockaddr *)&conn->remote_in, &conn->addrlen)) == -1) {
+		if (_getdns_socketerror() == _getdns_ECONNRESET) {
+			/*
+			 * WINSOCK gives ECONNRESET on ICMP Port Unreachable
+			 * being received. Ignore it.
+			 * */
+			GETDNS_FREE(*mf, conn);
+			return;
+		}
 		/* IO error, cleanup this listener. */
 		loop->vmt->clear(loop, &l->event);
 		_getdns_closesocket(l->fd);

--- a/src/stub.c
+++ b/src/stub.c
@@ -38,17 +38,6 @@
  */
 #define INTERCEPT_COM_DS 0
 
-#ifdef USE_POLL_DEFAULT_EVENTLOOP
-# ifdef HAVE_SYS_POLL_H
-#  include <sys/poll.h>
-# else
-#ifdef USE_WINSOCK
-#define poll(fdarray, nbsockets, timer) WSAPoll(fdarray, nbsockets, timer)
-#else
-#  include <poll.h>
-#endif
-# endif
-#endif
 #include "debug.h"
 #include <openssl/err.h>
 #include <openssl/conf.h>
@@ -426,13 +415,10 @@ tcp_connect(getdns_upstream *upstream, getdns_transport_list_t transport)
 #endif
 	if (connect(fd, (struct sockaddr *)&upstream->addr,
 	    upstream->addr_len) == -1) {
-		if (_getdns_EINPROGRESS || _getdns_EWOULDBLOCK)
+		if (_getdns_socketerror() == _getdns_EINPROGRESS ||
+		    _getdns_socketerror() == _getdns_EWOULDBLOCK)
 			return fd;
-#ifdef USE_WINSOCK
-		closesocket(fd);
-#else
-		close(fd);
-#endif
+		_getdns_closesocket(fd);
 		return -1;
 	}
 	return fd;
@@ -443,22 +429,13 @@ tcp_connected(getdns_upstream *upstream) {
 	int error = 0;
 	socklen_t len = (socklen_t)sizeof(error);
 	getsockopt(upstream->fd, SOL_SOCKET, SO_ERROR, (void*)&error, &len);
-#ifdef USE_WINSOCK
-	if (error == WSAEINPROGRESS)
+	if (error == _getdns_EINPROGRESS)
 		return STUB_TCP_AGAIN;
-	else if (error == WSAEWOULDBLOCK) 
-		return STUB_TCP_WOULDBLOCK;
-	else if (error != 0)
-		return STUB_SETUP_ERROR;
-#else
-	if (error == EINPROGRESS)
-		return STUB_TCP_AGAIN;
-	else if (error == EWOULDBLOCK || error == EAGAIN) 
+	else if (error == _getdns_EWOULDBLOCK || error == _getdns_EAGAIN) 
 		return STUB_TCP_WOULDBLOCK;
 	else if (error != 0) {
 		return STUB_SETUP_ERROR;
 	}
-#endif
 	if (upstream->transport == GETDNS_TRANSPORT_TCP &&
 	    upstream->queries_sent == 0) {
 			upstream->conn_state = GETDNS_CONN_OPEN;
@@ -570,11 +547,7 @@ _getdns_cancel_stub_request(getdns_network_req *netreq)
 	           STUB_DEBUG_CLEANUP, __FUNC__, (void*)netreq);
 	stub_cleanup(netreq);
 	if (netreq->fd >= 0) {
-#ifdef USE_WINSOCK
-		closesocket(netreq->fd);
-#else
-		close(netreq->fd);
-#endif
+		_getdns_closesocket(netreq->fd);
 		netreq->fd = -1;
 	}
 }
@@ -589,11 +562,7 @@ stub_timeout_cb(void *userarg)
 	_getdns_netreq_change_state(netreq, NET_REQ_TIMED_OUT);
 	/* Handle upstream*/
 	if (netreq->fd >= 0) {
-#ifdef USE_WINSOCK
-		closesocket(netreq->fd);
-#else
-		close(netreq->fd);
-#endif
+		_getdns_closesocket(netreq->fd);
 		netreq->fd = -1;
 		netreq->upstream->udp_timeouts++;
 		if (netreq->upstream->udp_timeouts % 100 == 0)
@@ -650,7 +619,7 @@ upstream_setup_timeout_cb(void *userarg)
 #ifdef USE_POLL_DEFAULT_EVENTLOOP
 	fds.fd = upstream->fd;
 	fds.events = POLLOUT;
-	ret = poll(&fds, 1, 0);
+	ret = _getdns_poll(&fds, 1, 0);
 #else
 	FD_ZERO(&fds);
 	FD_SET((int)(upstream->fd), &fds);
@@ -690,7 +659,7 @@ stub_tcp_read(int fd, getdns_tcp_state *tcp, struct mem_funcs *mf)
 	}
 	read = recv(fd, (void *)tcp->read_pos, tcp->to_read, 0);
 	if (read < 0) {
-		if (_getdns_EWOULDBLOCK)
+		if (_getdns_socketerror() == _getdns_EWOULDBLOCK)
 			return STUB_TCP_WOULDBLOCK;
 		else
 			return STUB_TCP_ERROR;
@@ -807,11 +776,11 @@ stub_tcp_write(int fd, getdns_tcp_state *tcp, getdns_network_req *netreq)
 		    (struct sockaddr *)&(netreq->upstream->addr),
 		    netreq->upstream->addr_len);
 #endif
-		if ((written < 0 && (_getdns_EWOULDBLOCK ||
+		if ((written < 0 && (_getdns_socketerror() == _getdns_EWOULDBLOCK ||
 		/* Add the error case where the connection is in progress which is when
 		   a cookie is not available (e.g. when doing the first request to an
 		   upstream). We must let the handshake complete since non-blocking. */
-		                       _getdns_EINPROGRESS)) ||
+				     _getdns_socketerror() == _getdns_EINPROGRESS)) ||
 		     (size_t)written < pkt_len + 2) {
 
 			/* We couldn't write the whole packet.
@@ -847,7 +816,7 @@ stub_tcp_write(int fd, getdns_tcp_state *tcp, getdns_network_req *netreq)
 		                    tcp->write_buf_len - tcp->written);
 #endif
 		if (written == -1) {
-			if (_getdns_EWOULDBLOCK)
+			if (_getdns_socketerror() == _getdns_EWOULDBLOCK)
 				return STUB_TCP_WOULDBLOCK;
 			else {
 				DEBUG_STUB("%s %-35s: MSG: %p error while writing to TCP socket:"
@@ -1386,7 +1355,8 @@ stub_udp_read_cb(void *userarg)
 	                                       * i.e. overflow
 	                                       */
 	    0, NULL, NULL);
-	if (read == -1 && _getdns_EWOULDBLOCK)
+	if (read == -1 && (_getdns_socketerror() == _getdns_EWOULDBLOCK ||
+		           _getdns_socketerror() == _getdns_ECONNRESET))
 		return; /* Try again later */
 
 	if (read == -1) {
@@ -1398,11 +1368,7 @@ stub_udp_read_cb(void *userarg)
 		_getdns_netreq_change_state(netreq, NET_REQ_ERRORED);
 		/* Handle upstream*/
 		if (netreq->fd >= 0) {
-#ifdef USE_WINSOCK
-			closesocket(netreq->fd);
-#else
-			close(netreq->fd);
-#endif
+			_getdns_closesocket(netreq->fd);
 			netreq->fd = -1;
 			stub_next_upstream(netreq);
 		}
@@ -1422,11 +1388,7 @@ stub_udp_read_cb(void *userarg)
 
 	GETDNS_CLEAR_EVENT(dnsreq->loop, &netreq->event);
 
-#ifdef USE_WINSOCK
-	closesocket(netreq->fd);
-#else
-	close(netreq->fd);
-#endif
+	_getdns_closesocket(netreq->fd);
 	netreq->fd = -1;
 	while (GLDNS_TC_WIRE(netreq->response)) {
 		DEBUG_STUB("%s %-35s: MSG: %p TC bit set in response \n", STUB_DEBUG_READ, 
@@ -1519,11 +1481,7 @@ stub_udp_write_cb(void *userarg)
 		_getdns_netreq_change_state(netreq, NET_REQ_ERRORED);
 		/* Handle upstream*/
 		if (netreq->fd >= 0) {
-#ifdef USE_WINSOCK
-			closesocket(netreq->fd);
-#else
-			close(netreq->fd);
-#endif
+			_getdns_closesocket(netreq->fd);
 			netreq->fd = -1;
 			stub_next_upstream(netreq);
 		}
@@ -2055,11 +2013,7 @@ upstream_connect(getdns_upstream *upstream, getdns_transport_list_t transport,
 			if (upstream->tls_obj == NULL) {
 				upstream_failed(upstream, 1);
 				_getdns_upstream_reset(upstream);
-#ifdef USE_WINSOCK
-				closesocket(fd);
-#else
-				close(fd);
-#endif
+				_getdns_closesocket(fd);
 				return -1;
 			}
 			upstream->tls_hs_state = GETDNS_HS_WRITE;
@@ -2128,7 +2082,7 @@ upstream_find_for_netreq(getdns_network_req *netreq)
 			continue;
 
 		if (fd == -1) {
-			if (_getdns_EMFILE)
+			if (_getdns_socketerror() == _getdns_EMFILE)
 				return STUB_TRY_AGAIN_LATER;
 			return -1;
 		}

--- a/src/stub.c
+++ b/src/stub.c
@@ -808,13 +808,8 @@ stub_tcp_write(int fd, getdns_tcp_state *tcp, getdns_network_req *netreq)
 
 		/* Coming back from an earlier unfinished write or handshake.
 		 * Try to send remaining data */
-#ifdef USE_WINSOCK
 		written = send(fd, (void *)(tcp->write_buf + tcp->written),
 			tcp->write_buf_len - tcp->written, 0);
-#else
-		written = write(fd, tcp->write_buf     + tcp->written,
-		                    tcp->write_buf_len - tcp->written);
-#endif
 		if (written == -1) {
 			if (_getdns_socketerror() == _getdns_EWOULDBLOCK)
 				return STUB_TCP_WOULDBLOCK;

--- a/src/stub.c
+++ b/src/stub.c
@@ -52,6 +52,7 @@
 #include "rr-iter.h"
 #include "context.h"
 #include "util-internal.h"
+#include "platform.h"
 #include "general.h"
 #include "pubkey-pinning.h"
 

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -221,14 +221,42 @@ INLINE uint64_t _getdns_ms_until_expiry2(uint64_t expires, uint64_t *now_ms)
 
 #ifdef USE_WINSOCK
 typedef u_short sa_family_t;
-#define _getdns_EWOULDBLOCK (WSAGetLastError() == WSATRY_AGAIN ||\
-		                             WSAGetLastError() == WSAEWOULDBLOCK)
-#define _getdns_EINPROGRESS (WSAGetLastError() == WSAEINPROGRESS)
-#define _getdns_EMFILE      (WSAGetLastError() == WSAEMFILE)
+#define _getdns_EAGAIN      (WSATRY_AGAIN)
+#define _getdns_EWOULDBLOCK (WSAEWOULDBLOCK)
+#define _getdns_EINPROGRESS (WSAEINPROGRESS)
+#define _getdns_EMFILE      (WSAEMFILE)
+#define _getdns_ECONNRESET  (WSAECONNRESET)
+
+#define _getdns_closesocket(fd) closesocket(fd)
+#define _getdns_poll(fdarray, nsockets, timer) WSAPoll(fdarray, nsockets, timer)
+#define _getdns_socketerror() (WSAGetLastError())
 #else
-#define _getdns_EWOULDBLOCK (errno == EAGAIN || errno == EWOULDBLOCK)
-#define _getdns_EINPROGRESS (errno == EINPROGRESS)
-#define _getdns_EMFILE      (errno == EMFILE)
+#ifdef HAVE_SYS_POLL_H
+# include <sys/poll.h>
+#else
+# include <poll.h>
+#endif
+
+#define _getdns_EAGAIN      (EAGAIN)
+#define _getdns_EWOULDBLOCK (EWOULDBLOCK)
+#define _getdns_EINPROGRESS (EINPROGRESS)
+#define _getdns_EMFILE      (EMFILE)
+#define _getdns_ECONNRESET  (ECONNRESET)
+
+#define SOCKADDR struct sockaddr
+#define SOCKADDR_IN struct sockaddr_in
+#define SOCKADDR_IN6 struct sockaddr_in6
+#define SOCKADDR_STORAGE struct sockaddr_storage
+#define SOCKET int
+
+#define IP_MREQ struct ip_mreq
+#define IPV6_MREQ struct ipv6_mreq
+#define BOOL int
+#define TRUE 1
+
+#define _getdns_closesocket(fd) close(fd)
+#define _getdns_poll(fdarray, nsockets, timer) poll(fdarray, nsockets, timer)
+#define _getdns_socketerror() (errno)
 #endif
 
 #endif

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -218,46 +218,5 @@ INLINE uint64_t _getdns_ms_until_expiry2(uint64_t expires, uint64_t *now_ms)
 	return *now_ms >= expires ? 0 : expires - *now_ms;
 }
 
-
-#ifdef USE_WINSOCK
-typedef u_short sa_family_t;
-#define _getdns_EAGAIN      (WSATRY_AGAIN)
-#define _getdns_EWOULDBLOCK (WSAEWOULDBLOCK)
-#define _getdns_EINPROGRESS (WSAEINPROGRESS)
-#define _getdns_EMFILE      (WSAEMFILE)
-#define _getdns_ECONNRESET  (WSAECONNRESET)
-
-#define _getdns_closesocket(fd) closesocket(fd)
-#define _getdns_poll(fdarray, nsockets, timer) WSAPoll(fdarray, nsockets, timer)
-#define _getdns_socketerror() (WSAGetLastError())
-#else
-#ifdef HAVE_SYS_POLL_H
-# include <sys/poll.h>
-#else
-# include <poll.h>
-#endif
-
-#define _getdns_EAGAIN      (EAGAIN)
-#define _getdns_EWOULDBLOCK (EWOULDBLOCK)
-#define _getdns_EINPROGRESS (EINPROGRESS)
-#define _getdns_EMFILE      (EMFILE)
-#define _getdns_ECONNRESET  (ECONNRESET)
-
-#define SOCKADDR struct sockaddr
-#define SOCKADDR_IN struct sockaddr_in
-#define SOCKADDR_IN6 struct sockaddr_in6
-#define SOCKADDR_STORAGE struct sockaddr_storage
-#define SOCKET int
-
-#define IP_MREQ struct ip_mreq
-#define IPV6_MREQ struct ipv6_mreq
-#define BOOL int
-#define TRUE 1
-
-#define _getdns_closesocket(fd) close(fd)
-#define _getdns_poll(fdarray, nsockets, timer) poll(fdarray, nsockets, timer)
-#define _getdns_socketerror() (errno)
-#endif
-
 #endif
 /* util-internal.h */


### PR DESCRIPTION
I was unable to resist a little tidying on the Winsock handling code. To whit:

- Create _getdns_closesocket(), _getdns_poll() to wrap #ifdef WINSOCK ... #endif items.
- Create _getdns_socketerror() to return WSAGetLastError() or errno depending on platform.
- Convert _getdns_E* to just the required constants, not the check, so errors from getsockopt() SO_ERROR can be compared with them.
- Add ECONNRESET.

And finally handle Winsock's bizzare returning of ECONNRESET on recvfrom() on a UDP socket by ignoring it.

Further work in progress to handle Winsock potentially doing the same on sendto().