### PR TITLE
More mingw polishing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,7 @@ esac
 
 
 DEFAULT_EVENTLOOP=select_eventloop
-AC_CHECK_HEADERS([sys/poll.h poll.h sys/resource.h sys/types.h],,, [AC_INCLUDES_DEFAULT])
+AC_CHECK_HEADERS([signal.h sys/poll.h poll.h sys/resource.h sys/types.h],,, [AC_INCLUDES_DEFAULT])
 AC_ARG_ENABLE(poll-eventloop, AC_HELP_STRING([--disable-poll-eventloop], [Disable default eventloop based on poll (default=enabled if available)]))
 case "$enable_poll_eventloop" in
 	no)
@@ -677,29 +677,29 @@ if test "$USE_WINSOCK" = 1; then
 	LIBS="$LIBS -lgdi32 -liphlpapi"
 fi
 
-dnl Check if -D_POSIX is needed for sigset_t
-
-AC_CHECK_TYPE([sigset_t], [
-	AC_MSG_NOTICE(-D_POSIX is NOT needed for the sigset_t type)
-], [
-	BACKCFLAGS="$CFLAGS"
-	CFLAGS="-D_POSIX $CFLAGS"
-	AC_CHECK_TYPE([sigset_t], [
-		AC_MSG_NOTICE(-D_POSIX is needed for the sigset_t type)
-	], [
-		AC_MSG_NOTICE(Unclear whether -D_POSIX is needed for the sigset_t type)
-		BACKCFLAGS="$CFLAGS"
-	], [AC_INCLUDES_DEFAULT
+dnl sigset_t or _sigset_t? MinGW is latter by default.
+AC_CHECK_TYPES([sigset_t],
+               [],
+               [AC_CHECK_TYPES([_sigset_t],
+                               [],
+                               [AC_MSG_ERROR([Can't find type `sigset_t' or type `_sigset_t'])],
+                               [AC_INCLUDES_DEFAULT
+#ifdef HAVE_SIGNAL_H
+#include <signal.h>
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-	])
-], [AC_INCLUDES_DEFAULT
+                               ])
+              ],
+              [AC_INCLUDES_DEFAULT
+#ifdef HAVE_SIGNAL_H
+#include <signal.h>
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
 ])
-
 AC_CHECK_FUNCS(sigemptyset sigfillset sigaddset)
 
 my_with_libidn=1
@@ -1566,11 +1566,14 @@ struct tm;
 char *strptime(const char *s, const char *format, struct tm *tm);
 #endif
 
+#if !defined(HAVE_SIGSET_T) && defined(HAVE__SIGSET_T)
+typedef _sigset_t sigset_t;
+#endif
 #if !defined(HAVE_SIGEMPTYSET)
 #  define sigemptyset(pset)    (*(pset) = 0)
 #endif
 #if !defined(HAVE_SIGFILLSET)
-#  define sigfillset(pset)     (*(pset) = (_sigset_t)-1)
+#  define sigfillset(pset)     (*(pset) = (sigset_t)-1)
 #endif
 #if !defined(HAVE_SIGADDSET)
 #  define sigaddset(pset, num) (*(pset) |= (1L<<(num)))

--- a/configure.ac
+++ b/configure.ac
@@ -1376,12 +1376,6 @@ AH_BOTTOM([
 #  include <winsock2.h>
 # endif
 
-# ifndef USE_WINSOCK
-#  define ARG_LL "%ll"
-# else
-#  define ARG_LL "%I64"
-# endif
-
 /* detect if we need to cast to unsigned int for FD_SET to avoid warnings */
 # ifdef HAVE_WINSOCK2_H
 #  define FD_SET_T (u_int)

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -77,7 +77,7 @@ C99COMPATFLAGS=@C99COMPATFLAGS@
 DEFAULT_EVENTLOOP_OBJ=@DEFAULT_EVENTLOOP@.lo
 
 GETDNS_OBJ=const-info.lo convert.lo dict.lo dnssec.lo general.lo \
-	list.lo request-internal.lo pubkey-pinning.lo rr-dict.lo \
+	list.lo request-internal.lo platform.lo pubkey-pinning.lo rr-dict.lo \
 	rr-iter.lo server.lo stub.lo sync.lo ub_loop.lo util-internal.lo \
 	mdns.lo
 
@@ -281,8 +281,7 @@ depend:
 FORCE:
 
 # Dependencies for gldns, utils, the extensions and compat functions
-anchor.lo anchor.o: $(srcdir)/anchor.c \
- config.h \
+anchor.lo anchor.o: $(srcdir)/anchor.c config.h \
  $(srcdir)/debug.h $(srcdir)/anchor.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
@@ -293,15 +292,13 @@ anchor.lo anchor.o: $(srcdir)/anchor.c \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h $(srcdir)/yxml/yxml.h \
  $(srcdir)/gldns/parseutil.h $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/wire2str.h \
- $(srcdir)/gldns/keyraw.h $(srcdir)/general.h $(srcdir)/util-internal.h
+ $(srcdir)/gldns/keyraw.h $(srcdir)/general.h $(srcdir)/util-internal.h $(srcdir)/platform.h
 const-info.lo const-info.o: $(srcdir)/const-info.c \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/const-info.h
-context.lo context.o: $(srcdir)/context.c \
- config.h \
- $(srcdir)/anchor.h \
- getdns/getdns.h \
+context.lo context.o: $(srcdir)/context.c config.h \
+ $(srcdir)/anchor.h getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h $(srcdir)/debug.h \
  $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/wire2str.h $(srcdir)/context.h \
@@ -309,36 +306,33 @@ context.lo context.o: $(srcdir)/context.c \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
  $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
- $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/util-internal.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h \
- $(srcdir)/stub.h $(srcdir)/list.h $(srcdir)/dict.h $(srcdir)/pubkey-pinning.h
-convert.lo convert.o: $(srcdir)/convert.c \
- config.h \
+ $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/util-internal.h $(srcdir)/platform.h $(srcdir)/dnssec.h \
+ $(srcdir)/gldns/rrdef.h $(srcdir)/stub.h $(srcdir)/list.h $(srcdir)/dict.h $(srcdir)/pubkey-pinning.h
+convert.lo convert.o: $(srcdir)/convert.c config.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/util-internal.h $(srcdir)/context.h $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h \
  $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/extension/default_eventloop.h \
- $(srcdir)/extension/poll_eventloop.h $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h \
+ $(srcdir)/extension/poll_eventloop.h $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h \
  $(srcdir)/util/lruhash.h $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h \
  $(srcdir)/util/orig-headers/locks.h $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h \
  $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/gldns/wire2str.h \
  $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/parseutil.h $(srcdir)/const-info.h $(srcdir)/dict.h \
- $(srcdir)/list.h $(srcdir)/jsmn/jsmn.h $(stubbysrcdir)/src/yaml/convert_yaml_to_json.h $(srcdir)/convert.h
-dict.lo dict.o: $(srcdir)/dict.c \
- config.h \
+ $(srcdir)/list.h $(srcdir)/jsmn/jsmn.h $(stubbysrcdir)/src/yaml/convert_yaml_to_json.h $(srcdir)/convert.h \
+ $(srcdir)/debug.h
+dict.lo dict.o: $(srcdir)/dict.c config.h \
  $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/util-internal.h $(srcdir)/context.h \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
- $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
  $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/dict.h $(srcdir)/list.h $(srcdir)/const-info.h $(srcdir)/gldns/wire2str.h \
  $(srcdir)/gldns/parseutil.h
-dnssec.lo dnssec.o: $(srcdir)/dnssec.c \
- config.h \
- $(srcdir)/debug.h \
- getdns/getdns.h \
+dnssec.lo dnssec.o: $(srcdir)/dnssec.c config.h \
+ $(srcdir)/debug.h getdns/getdns.h \
  $(srcdir)/context.h \
  getdns/getdns_extra.h \
  $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h \
@@ -350,31 +344,28 @@ dnssec.lo dnssec.o: $(srcdir)/dnssec.c \
  $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/wire2str.h $(srcdir)/gldns/keyraw.h \
  $(srcdir)/gldns/parseutil.h $(srcdir)/general.h $(srcdir)/dict.h $(srcdir)/list.h $(srcdir)/util/val_secalgo.h \
  $(srcdir)/util/orig-headers/val_secalgo.h
-general.lo general.o: $(srcdir)/general.c \
- config.h \
- $(srcdir)/general.h \
- getdns/getdns.h \
+general.lo general.o: $(srcdir)/general.c config.h \
+ $(srcdir)/general.h getdns/getdns.h \
  $(srcdir)/types-internal.h \
  getdns/getdns_extra.h \
- $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/ub_loop.h $(srcdir)/debug.h \
- $(srcdir)/gldns/wire2str.h $(srcdir)/context.h $(srcdir)/extension/default_eventloop.h \
- $(srcdir)/extension/poll_eventloop.h $(srcdir)/types-internal.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/gldns/wire2str.h $(srcdir)/context.h \
+ $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
  $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/util-internal.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h $(srcdir)/stub.h \
- $(srcdir)/dict.h $(srcdir)/mdns.h
+ $(srcdir)/dict.h $(srcdir)/mdns.h $(srcdir)/platform.h $(srcdir)/debug.h
 list.lo list.o: $(srcdir)/list.c $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/util-internal.h \
- config.h \
- $(srcdir)/context.h $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
- $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ config.h $(srcdir)/context.h \
+ $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
  $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/list.h $(srcdir)/dict.h
-mdns.lo mdns.o: $(srcdir)/mdns.c \
- config.h \
+mdns.lo mdns.o: $(srcdir)/mdns.c config.h \
  $(srcdir)/debug.h $(srcdir)/context.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
@@ -383,14 +374,13 @@ mdns.lo mdns.o: $(srcdir)/mdns.c \
  $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
- $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/general.h $(srcdir)/gldns/rrdef.h $(srcdir)/util-internal.h $(srcdir)/mdns.h \
- $(srcdir)/util/auxiliary/util/fptr_wlist.h $(srcdir)/util/lookup3.h \
+ $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/general.h $(srcdir)/gldns/rrdef.h $(srcdir)/util-internal.h \
+ $(srcdir)/platform.h $(srcdir)/mdns.h $(srcdir)/util/auxiliary/util/fptr_wlist.h $(srcdir)/util/lookup3.h \
  $(srcdir)/util/orig-headers/lookup3.h
+platform.lo platform.o: $(srcdir)/platform.c
 pubkey-pinning.lo pubkey-pinning.o: $(srcdir)/pubkey-pinning.c \
- config.h \
- $(srcdir)/debug.h \
- getdns/getdns.h \
- $(srcdir)/context.h \
+ config.h $(srcdir)/debug.h \
+ getdns/getdns.h $(srcdir)/context.h \
  getdns/getdns_extra.h \
  $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
@@ -399,17 +389,16 @@ pubkey-pinning.lo pubkey-pinning.o: $(srcdir)/pubkey-pinning.c \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
  $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/util-internal.h
 request-internal.lo request-internal.o: $(srcdir)/request-internal.c \
- config.h \
- $(srcdir)/types-internal.h \
+ config.h $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/util-internal.h $(srcdir)/context.h \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
- $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
  $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h \
- $(srcdir)/dict.h $(srcdir)/convert.h $(srcdir)/general.h
+ $(srcdir)/dict.h $(srcdir)/debug.h $(srcdir)/convert.h $(srcdir)/general.h
 rr-dict.lo rr-dict.o: $(srcdir)/rr-dict.c $(srcdir)/rr-dict.h \
  config.h \
  getdns/getdns.h \
@@ -417,7 +406,7 @@ rr-dict.lo rr-dict.o: $(srcdir)/rr-dict.c $(srcdir)/rr-dict.h \
  getdns/getdns_extra.h \
  $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
- $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h \
  $(srcdir)/dict.h
@@ -425,18 +414,16 @@ rr-iter.lo rr-iter.o: $(srcdir)/rr-iter.c $(srcdir)/rr-iter.h $(srcdir)/rr-dict.
  config.h \
  getdns/getdns.h \
  $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h $(srcdir)/gldns/rrdef.h
-server.lo server.o: $(srcdir)/server.c \
- config.h \
+server.lo server.o: $(srcdir)/server.c config.h \
  getdns/getdns_extra.h \
- getdns/getdns.h \
- $(srcdir)/context.h $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h \
+ getdns/getdns.h $(srcdir)/context.h \
+ $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
- $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
- $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h
-stub.lo stub.o: $(srcdir)/stub.c \
- config.h \
+ $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/debug.h $(srcdir)/util-internal.h $(srcdir)/platform.h
+stub.lo stub.o: $(srcdir)/stub.c config.h \
  $(srcdir)/debug.h $(srcdir)/stub.h \
  getdns/getdns.h \
  $(srcdir)/types-internal.h \
@@ -447,58 +434,51 @@ stub.lo stub.o: $(srcdir)/stub.c \
  $(srcdir)/extension/poll_eventloop.h $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h \
  $(srcdir)/util/lruhash.h $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h \
  $(srcdir)/util/orig-headers/locks.h $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/anchor.h \
- $(srcdir)/util-internal.h $(srcdir)/general.h $(srcdir)/pubkey-pinning.h
-sync.lo sync.o: $(srcdir)/sync.c \
- getdns/getdns.h \
- config.h \
- $(srcdir)/context.h \
+ $(srcdir)/util-internal.h $(srcdir)/platform.h $(srcdir)/general.h $(srcdir)/pubkey-pinning.h
+sync.lo sync.o: $(srcdir)/sync.c getdns/getdns.h \
+ config.h $(srcdir)/context.h \
  getdns/getdns_extra.h \
  $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h \
  $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
- $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
  $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/general.h $(srcdir)/util-internal.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h \
  $(srcdir)/stub.h $(srcdir)/gldns/wire2str.h
 ub_loop.lo ub_loop.o: $(srcdir)/ub_loop.c $(srcdir)/ub_loop.h \
- config.h \
- getdns/getdns.h \
- getdns/getdns_extra.h \
- $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/debug.h
+ config.h
 util-internal.lo util-internal.o: $(srcdir)/util-internal.c \
  config.h \
- getdns/getdns.h \
- $(srcdir)/dict.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/types-internal.h \
- getdns/getdns_extra.h \
- $(srcdir)/list.h $(srcdir)/util-internal.h $(srcdir)/context.h $(srcdir)/extension/default_eventloop.h \
- $(srcdir)/extension/poll_eventloop.h $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/debug.h $(srcdir)/server.h \
+ getdns/getdns.h $(srcdir)/dict.h \
+ $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/types-internal.h \
+ getdns/getdns_extra.h $(srcdir)/list.h \
+ $(srcdir)/util-internal.h $(srcdir)/context.h $(srcdir)/extension/default_eventloop.h \
+ $(srcdir)/extension/poll_eventloop.h $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h \
  $(srcdir)/util/lruhash.h $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h \
  $(srcdir)/util/orig-headers/locks.h $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h \
  $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/gldns/str2wire.h \
  $(srcdir)/gldns/rrdef.h $(srcdir)/dnssec.h $(srcdir)/gldns/rrdef.h
 gbuffer.lo gbuffer.o: $(srcdir)/gldns/gbuffer.c \
- config.h \
- $(srcdir)/gldns/gbuffer.h
+ config.h $(srcdir)/gldns/gbuffer.h
 keyraw.lo keyraw.o: $(srcdir)/gldns/keyraw.c \
- config.h \
- $(srcdir)/gldns/keyraw.h $(srcdir)/gldns/rrdef.h
+ config.h $(srcdir)/gldns/keyraw.h \
+ $(srcdir)/gldns/rrdef.h
 parse.lo parse.o: $(srcdir)/gldns/parse.c \
- config.h \
- $(srcdir)/gldns/parse.h $(srcdir)/gldns/parseutil.h $(srcdir)/gldns/gbuffer.h
+ config.h $(srcdir)/gldns/parse.h \
+ $(srcdir)/gldns/parseutil.h $(srcdir)/gldns/gbuffer.h
 parseutil.lo parseutil.o: $(srcdir)/gldns/parseutil.c \
- config.h \
- $(srcdir)/gldns/parseutil.h
+ config.h $(srcdir)/gldns/parseutil.h
 rrdef.lo rrdef.o: $(srcdir)/gldns/rrdef.c \
- config.h \
- $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/parseutil.h
+ config.h $(srcdir)/gldns/rrdef.h \
+ $(srcdir)/gldns/parseutil.h
 str2wire.lo str2wire.o: $(srcdir)/gldns/str2wire.c \
- config.h \
- $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/wire2str.h $(srcdir)/gldns/gbuffer.h \
- $(srcdir)/gldns/parse.h $(srcdir)/gldns/parseutil.h
+ config.h $(srcdir)/gldns/str2wire.h \
+ $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/wire2str.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/parse.h \
+ $(srcdir)/gldns/parseutil.h
 wire2str.lo wire2str.o: $(srcdir)/gldns/wire2str.c \
- config.h \
- $(srcdir)/gldns/wire2str.h $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/pkthdr.h \
- $(srcdir)/gldns/parseutil.h $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/keyraw.h
+ config.h $(srcdir)/gldns/wire2str.h \
+ $(srcdir)/gldns/str2wire.h $(srcdir)/gldns/rrdef.h $(srcdir)/gldns/pkthdr.h $(srcdir)/gldns/parseutil.h \
+ $(srcdir)/gldns/gbuffer.h $(srcdir)/gldns/keyraw.h
 arc4_lock.lo arc4_lock.o: $(srcdir)/compat/arc4_lock.c \
  config.h
 arc4random.lo arc4random.o: $(srcdir)/compat/arc4random.c \
@@ -527,8 +507,7 @@ strlcpy.lo strlcpy.o: $(srcdir)/compat/strlcpy.c \
  config.h
 strptime.lo strptime.o: $(srcdir)/compat/strptime.c \
  config.h
-locks.lo locks.o: $(srcdir)/util/locks.c \
- config.h \
+locks.lo locks.o: $(srcdir)/util/locks.c config.h \
  $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h
 lookup3.lo lookup3.o: $(srcdir)/util/lookup3.c \
  config.h \
@@ -540,10 +519,10 @@ lruhash.lo lruhash.o: $(srcdir)/util/lruhash.c \
  $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
  $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/util/auxiliary/util/fptr_wlist.h
 rbtree.lo rbtree.o: $(srcdir)/util/rbtree.c \
- config.h \
- $(srcdir)/util/auxiliary/log.h $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h \
- $(srcdir)/util/auxiliary/fptr_wlist.h $(srcdir)/util/auxiliary/util/fptr_wlist.h \
- $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h
+ config.h $(srcdir)/util/auxiliary/log.h \
+ $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/util/auxiliary/fptr_wlist.h \
+ $(srcdir)/util/auxiliary/util/fptr_wlist.h $(srcdir)/util/rbtree.h \
+ $(srcdir)/util/orig-headers/rbtree.h
 val_secalgo.lo val_secalgo.o: $(srcdir)/util/val_secalgo.c \
  config.h \
  $(srcdir)/util/auxiliary/util/data/packed_rrset.h \
@@ -555,37 +534,41 @@ val_secalgo.lo val_secalgo.o: $(srcdir)/util/val_secalgo.c \
 jsmn.lo jsmn.o: $(srcdir)/jsmn/jsmn.c $(srcdir)/jsmn/jsmn.h
 yxml.lo yxml.o: $(srcdir)/yxml/yxml.c $(srcdir)/yxml/yxml.h
 libev.lo libev.o: $(srcdir)/extension/libev.c \
- config.h \
- $(srcdir)/types-internal.h \
+ config.h $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/getdns/getdns_ext_libev.h
 libevent.lo libevent.o: $(srcdir)/extension/libevent.c \
- config.h \
- $(srcdir)/types-internal.h \
+ config.h $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/getdns/getdns_ext_libevent.h
 libuv.lo libuv.o: $(srcdir)/extension/libuv.c \
- config.h \
- $(srcdir)/debug.h $(srcdir)/types-internal.h \
+ config.h $(srcdir)/debug.h \
+ $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/getdns/getdns_ext_libuv.h
 poll_eventloop.lo poll_eventloop.o: $(srcdir)/extension/poll_eventloop.c \
- config.h \
- $(srcdir)/extension/poll_eventloop.h \
- getdns/getdns.h \
+ config.h $(srcdir)/util-internal.h \
+ $(srcdir)/context.h getdns/getdns.h \
  getdns/getdns_extra.h \
- $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/debug.h
+ $(srcdir)/types-internal.h $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h \
+ $(srcdir)/extension/default_eventloop.h $(srcdir)/extension/poll_eventloop.h \
+ $(srcdir)/types-internal.h $(srcdir)/ub_loop.h $(srcdir)/server.h $(srcdir)/util/lruhash.h \
+ $(srcdir)/util/orig-headers/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/orig-headers/locks.h \
+ $(srcdir)/util/auxiliary/util/log.h $(srcdir)/debug.h $(srcdir)/rr-iter.h $(srcdir)/rr-dict.h $(srcdir)/gldns/gbuffer.h \
+ $(srcdir)/gldns/pkthdr.h $(srcdir)/anchor.h $(srcdir)/platform.h
 select_eventloop.lo select_eventloop.o: $(srcdir)/extension/select_eventloop.c \
- config.h \
- $(srcdir)/debug.h $(srcdir)/types-internal.h \
+ config.h $(srcdir)/debug.h \
+ $(srcdir)/types-internal.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
- $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/extension/select_eventloop.h
+ $(srcdir)/util/rbtree.h $(srcdir)/util/orig-headers/rbtree.h $(srcdir)/platform.h \
+ $(srcdir)/extension/select_eventloop.h
 stubby.lo stubby.o: $(stubbysrcdir)/src/stubby.c \
  config.h \
  getdns/getdns.h \
  getdns/getdns_extra.h \
  $(stubbysrcdir)/src/yaml/convert_yaml_to_json.h
+version.lo version.o: $(stubbysrcdir)/src/version.c

--- a/src/debug.h
+++ b/src/debug.h
@@ -59,6 +59,20 @@
 		fprintf(stderr, "[%s.%.6d] ", buf_dEbUgSyM, (int)tv_dEbUgSyM.tv_usec); \
 		fprintf(stderr, __VA_ARGS__); \
 	} while (0)
+
+#define DEBUG_NL(...) do {		    \
+		struct timeval tv_dEbUgSyM; \
+		struct tm tm_dEbUgSyM; \
+		char buf_dEbUgSyM[10]; \
+		time_t tsec_dEbUgSyM; \
+		\
+		gettimeofday(&tv_dEbUgSyM, NULL); \
+		tsec_dEbUgSyM = (time_t) tv_dEbUgSyM.tv_sec; \
+		gmtime_s(&tm_dEbUgSyM, (const time_t *) &tsec_dEbUgSyM); \
+		strftime(buf_dEbUgSyM, 10, "%H:%M:%S", &tm_dEbUgSyM); \
+		fprintf(stderr, "[%s.%.6d] ", buf_dEbUgSyM, (int)tv_dEbUgSyM.tv_usec); \
+		fprintf(stderr, __VA_ARGS__); \
+	} while (0)
 #else
 #define DEBUG_ON(...) do { \
 		struct timeval tv_dEbUgSyM; \
@@ -71,9 +85,8 @@
 		fprintf(stderr, "[%s.%.6d] ", buf_dEbUgSyM, (int)tv_dEbUgSyM.tv_usec); \
 		fprintf(stderr, __VA_ARGS__); \
 	} while (0)
-#endif
 
-#define DEBUG_NL(...) do { \
+#define DEBUG_NL(...) do {		    \
 		struct timeval tv_dEbUgSyM; \
 		struct tm tm_dEbUgSyM; \
 		char buf_dEbUgSyM[10]; \
@@ -85,7 +98,7 @@
 		fprintf(stderr, __VA_ARGS__); \
 		fprintf(stderr, "\n"); \
 	} while (0)
-
+#endif
 
 #define DEBUG_OFF(...) do {} while (0)
 

--- a/src/extension/poll_eventloop.c
+++ b/src/extension/poll_eventloop.c
@@ -408,7 +408,7 @@ poll_eventloop_run_once(getdns_eventloop *loop, int blocking)
     } else
 #endif
 	if (_getdns_poll(poll_loop->pfds, poll_loop->fd_events_free, poll_timeout) < 0) {
-		perror("poll() failed");
+		_getdns_perror("poll() failed");
 		exit(EXIT_FAILURE);
 	}
 	now = get_now_plus(0);

--- a/src/extension/select_eventloop.c
+++ b/src/extension/select_eventloop.c
@@ -29,6 +29,7 @@
 
 #include "debug.h"
 #include "types-internal.h"
+#include "platform.h"
 #include "extension/select_eventloop.h"
 
 static uint64_t get_now_plus(uint64_t amount)
@@ -244,7 +245,7 @@ select_eventloop_run_once(getdns_eventloop *loop, int blocking)
 #endif
 	if (select(max_fd + 1, &readfds, &writefds, NULL,
 	    (timeout == TIMEOUT_FOREVER ? NULL : &tv)) < 0) {
-		perror("select() failed");
+		_getdns_perror("select() failed");
 		exit(EXIT_FAILURE);
 	}
 #ifdef USE_WINSOCK

--- a/src/gldns/wire2str.c
+++ b/src/gldns/wire2str.c
@@ -1059,11 +1059,7 @@ int gldns_wire2str_tsigtime_scan(uint8_t** d, size_t* dl, char** s, size_t* sl)
 	d4 = (*d)[4];
 	d5 = (*d)[5];
 	tsigtime = (d0<<40) | (d1<<32) | (d2<<24) | (d3<<16) | (d4<<8) | d5;
-#ifndef USE_WINSOCK
-	w = gldns_str_print(s, sl, "%llu", (long long)tsigtime);
-#else
-	w = gldns_str_print(s, sl, "%I64u", (long long)tsigtime);
-#endif
+	w = gldns_str_print(s, sl, "%"PRIu64, (uint64_t)tsigtime);
 	(*d)+=6;
 	(*dl)-=6;
 	return w;
@@ -1746,13 +1742,8 @@ int gldns_wire2str_edns_llq_print(char** s, size_t* sl, uint8_t* data,
 	if(error_code < llq_errors_num)
 		w += gldns_str_print(s, sl, " %s", llq_errors[error_code]);
 	else	w += gldns_str_print(s, sl, " error %d", (int)error_code);
-#ifndef USE_WINSOCK
-	w += gldns_str_print(s, sl, " id %llx lease-life %lu",
-		(unsigned long long)llq_id, (unsigned long)lease_life);
-#else
-	w += gldns_str_print(s, sl, " id %I64x lease-life %lu",
-		(unsigned long long)llq_id, (unsigned long)lease_life);
-#endif
+	w += gldns_str_print(s, sl, " id %"PRIx64" lease-life %lu",
+		(uint64_t)llq_id, (unsigned long)lease_life);
 	return w;
 }
 


### PR DESCRIPTION
- Redo sigset_t check. Include signal.h, as Posix says that's where it's defined. On failure, check for _sigset_t.
- Have Winsock and non-WInsock DEBUG_NL as with DEBUG_ON.
- Add _getdns_perror() to report Winsock errors.
- Remove ARG_LL, use PRIxxx instead, and so remove some #ifdef WINSOCK..#else...#endif.