### PR TITLE
Fix a linking issue in stubby when libbsd is present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1270,6 +1270,7 @@ fi
 # system implementation.
 PKG_CHECK_MODULES([LIBBSD],[libbsd-overlay],[
 LIBS="$LIBS $LIBBSD_LIBS"
+STUBBY_LIBS="$STUBBY_LIBS $LIBBSD_LIBS"
 CFLAGS="$CFLAGS $LIBBSD_CFLAGS"
 ],[
 AC_MSG_WARN([libbsd not found or usable; using embedded code instead])


### PR DESCRIPTION
On Arch, when libbsd is found on the system during the configure, the result of `pkg-config --cflags libbsd-overlay` is added to `CFLAGS`:

`-DLIBBSD_OVERLAY -isystem /usr/include/bsd`

The result of `pkg-config --libs libbsd-overlay` is added to `LIBS`, but not to `STUBBY_LIBS`, which is used when linking stubby.

Because of the new `CFLAGS`, the preprocessor replaces the call to `getopt()` in stubby.c with a call to `bsd_getop()`:

```
 #ifdef LIBBSD_OVERLAY
 #undef getopt
 #define getopt(argc, argv, optstr) bsd_getopt(argc, argv, optstr)
 #endif
```

But since `-lbsd` has not been added to `STUBBY_LIBS`, the linking of stubby fails with an unresolved symbol:

```
../libtool --tag=CC --mode=link gcc -o stubby stubby.lo convert_yaml_to_json.lo gbuffer.lo -lyaml  libgetdns.la
libtool: link: gcc -o .libs/stubby .libs/stubby.o .libs/convert_yaml_to_json.o .libs/gbuffer.o  -lyaml ./.libs/libgetdns.so
/usr/bin/ld: .libs/stubby.o: undefined reference to symbol 'bsd_getopt@@LIBBSD_0.0'
/usr/lib/libbsd.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

Simply adding the result of `pkg-config --libs libbsd-overlay` to `STUBBY_LIBS` in addition to `LIBS` fixes the issue. Note that another, perhaps cleaner, option would be to separate the `CFLAGS` used to build stubby from the rest of the project, but it seems much more painful than this one since the same variable is currently used everywhere.