### PR TITLE
Update makefile because a file in Stubby was moved

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -253,7 +253,7 @@ $(distdir):
 	cp $(srcdir)/src/tools/Makefile.in $(distdir)/src/tools
 	cp $(srcdir)/src/tools/*.[ch] $(distdir)/src/tools
 	cp $(srcdir)/stubby/stubby.yml.example $(distdir)/stubby
-	cp $(srcdir)/stubby/stubby-setdns-macos.sh $(distdir)/stubby
+	cp $(srcdir)/stubby/macos/stubby-setdns-macos.sh $(distdir)/stubby
 	cp $(srcdir)/stubby/src/*.[ch] $(distdir)/stubby/src
 	cp $(srcdir)/stubby/src/yaml/*.[ch] $(distdir)/stubby/src/yaml
 	cp $(srcdir)/stubby/COPYING $(distdir)/stubby

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -208,9 +208,9 @@ install-stubby-files-unix: $(stubbysrcdir)/stubby.yml.example
 	test -f $(DESTDIR)$(stubbyconfdir)/stubby.yml || \
 		$(INSTALL_DATA) $(stubbysrcdir)/stubby.yml.example $(DESTDIR)$(stubbyconfdir)/stubby.yml
 
-install-stubby-files-macos: $(stubbysrcdir)/stubby-setdns-macos.sh install-stubby-files-unix
+install-stubby-files-macos: $(stubbysrcdir)/macos/stubby-setdns-macos.sh install-stubby-files-unix
 	$(INSTALL) -m 755 -d $(DESTDIR)$(sbindir)
-	$(INSTALL) -m 755  $(stubbysrcdir)/stubby-setdns-macos.sh $(DESTDIR)$(sbindir)
+	$(INSTALL) -m 755  $(stubbysrcdir)/macos/stubby-setdns-macos.sh $(DESTDIR)$(sbindir)
 
 stubby.yml.windows: $(stubbysrcdir)/stubby.yml.example
 	awk "{sub(/$$/,\"\r\")}1" $(stubbysrcdir)/stubby.yml.example > stubby.yml.windows


### PR DESCRIPTION
Don't merge yet, needed when https://github.com/getdnsapi/stubby/pull/54 merged and the stubby commit is updated in getdns before the next release. 