### PR TITLE
Add support for TLS 1.3 and Chacha20-Poly1305

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -3574,7 +3574,7 @@ _getdns_context_prepare_for_resolution(getdns_context *context)
 #  endif
 			/* Be strict and only use the cipher suites recommended in RFC7525
 			   Unless we later fallback to opportunistic. */
-			const char* const PREFERRED_CIPHERS = "EECDH+aRSA+AESGCM:EECDH+aECDSA+AESGCM:EDH+aRSA+AESGCM";
+			const char* const PREFERRED_CIPHERS = "TLS13-AES-256-GCM-SHA384:TLS13-AES-128-GCM-SHA256:TLS13-CHACHA20-POLY1305-SHA256:EECDH+AESGCM:EECDH+CHACHA20";
 			if (!SSL_CTX_set_cipher_list(context->tls_ctx, PREFERRED_CIPHERS))
 				return GETDNS_RETURN_BAD_CONTEXT;
 			/* For strict authentication, we must have local root certs available


### PR DESCRIPTION
Add support for TLS 1.3 (requires OpenSSL 1.1.1) and Chacha20-Poly1305 (requires OpenSSL 1.1).

Older OpenSSL versions will simply ignore ciphersuite specifications they don't understand and use the subset which they do unterstand.

Note that "EECDH" does *not* select anonymous cipher suites (as opposed to "kECDHE").