### PR TITLE
src/stub.c: LibreSSL has hostname verification turned on by default

### DIFF
--- a/src/stub.c
+++ b/src/stub.c
@@ -942,13 +942,14 @@ tls_create_object(getdns_dns_req *dnsreq, int fd, getdns_upstream *upstream)
 		DEBUG_STUB("%s %-35s: Hostname verification requested for: %s\n",
 		           STUB_DEBUG_SETUP_TLS, __FUNC__, upstream->tls_auth_name);
 		SSL_set_tlsext_host_name(ssl, upstream->tls_auth_name);
-#ifdef HAVE_SSL_HN_AUTH
+#if defined(HAVE_SSL_HN_AUTH) && !defined(HAVE_LIBRESSL)
 		/* Set up native OpenSSL hostname verification*/
 		X509_VERIFY_PARAM *param;
 		param = SSL_get0_param(ssl);
 		X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
 		X509_VERIFY_PARAM_set1_host(param, upstream->tls_auth_name, 0);
-#else
+#endif
+#if !defined(HAVE_SSL_HN_AUTH) && !defined(HAVE_LIBRESSL)
 		if (dnsreq->netreqs[0]->tls_auth_min == GETDNS_AUTHENTICATION_REQUIRED) {
 			DEBUG_STUB("%s %-35s: ERROR: Hostname Authentication not available from TLS library (check library version)\n",
 		           STUB_DEBUG_SETUP_TLS, __FUNC__);


### PR DESCRIPTION
Tested on my Android phone