### PR TITLE
Bug388 endless loop tcp

### DIFF
--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -202,6 +202,7 @@ network_req_init(getdns_network_req *net_req, getdns_dns_req *owner,
 	/* state variables from the resolver, don't touch
 	 */
 	net_req->upstream = NULL;
+    net_req->first_stateful = -1;
 	net_req->fd = -1;
 	net_req->transport_current = 0;
 	memset(&net_req->event, 0, sizeof(net_req->event));

--- a/src/request-internal.c
+++ b/src/request-internal.c
@@ -202,7 +202,7 @@ network_req_init(getdns_network_req *net_req, getdns_dns_req *owner,
 	/* state variables from the resolver, don't touch
 	 */
 	net_req->upstream = NULL;
-    net_req->first_stateful = -1;
+	net_req->first_stateful = -1;
 	net_req->fd = -1;
 	net_req->transport_current = 0;
 	memset(&net_req->event, 0, sizeof(net_req->event));

--- a/src/stub.c
+++ b/src/stub.c
@@ -2265,17 +2265,17 @@ upstream_find_for_transport(getdns_network_req *netreq,
 			upstream = upstream_select_stateful(netreq, transport);
 			if (!upstream)
 				return NULL;
-            upstreams = netreq->owner->upstreams;
-            if (netreq->first_stateful < 0) {
-                netreq->first_stateful = upstream - upstreams->upstreams;
-            } else {
-                if (upstream == &upstreams->upstreams[netreq->first_stateful]) {
-                    /* Wrapped, looks like we tried all */
-                    DEBUG_STUB("%s %-35s: No more upstreams to try\n", 
-                               STUB_DEBUG_SETUP, __FUNC__);
-                    return NULL;
-                }
-            }
+			upstreams = netreq->owner->upstreams;
+			if (netreq->first_stateful < 0) {
+				netreq->first_stateful = upstream - upstreams->upstreams;
+			} else {
+				if (upstream == &upstreams->upstreams[netreq->first_stateful]) {
+					/* Wrapped, looks like we tried all */
+					DEBUG_STUB("%s %-35s: No more upstreams to try\n", 
+							   STUB_DEBUG_SETUP, __FUNC__);
+					return NULL;
+				}
+			}
 			*fd = upstream_connect(upstream, transport, netreq->owner);
 			if (i >= upstream->upstreams->count)
 				return NULL;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -222,7 +222,7 @@ typedef struct getdns_network_req
 
 	/* For stub resolving */
 	struct getdns_upstream *upstream;
-    int                     first_stateful;
+	int                     first_stateful;
 	int                     fd;
 	getdns_transport_list_t transports[GETDNS_TRANSPORTS_MAX];
 	size_t                  transport_count;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -222,6 +222,7 @@ typedef struct getdns_network_req
 
 	/* For stub resolving */
 	struct getdns_upstream *upstream;
+    int                     first_stateful;
 	int                     fd;
 	getdns_transport_list_t transports[GETDNS_TRANSPORTS_MAX];
 	size_t                  transport_count;


### PR DESCRIPTION
 Quick fix for #388: try all TCP upstreams not more than once for each request.

 Still not ideal as upstream_select_stateful() ignores the backoff state when
 no other is available, so each request will try each upstream again when none
 is available. This can cause a lot of TCP connection attempts...