### PR TITLE
No TCP sendto without TCP_FASTOPEN

### DIFF
--- a/src/stub.c
+++ b/src/stub.c
@@ -760,10 +760,7 @@ stub_tcp_write(int fd, getdns_tcp_state *tcp, getdns_network_req *netreq)
 		if (written == -1 && _getdns_socketerror() == _getdns_EISCONN) 
 			written = write(fd, netreq->query - 2, pkt_len + 2);
 #else
-		written = sendto(fd, (const char *)(netreq->query - 2),
-		    pkt_len + 2, 0,
-		    (struct sockaddr *)&(netreq->upstream->addr),
-		    netreq->upstream->addr_len);
+		written = write(fd, netreq->query - 2, pkt_len + 2);
 #endif
 		if ((written == -1 && _getdns_socketerror_wants_retry()) ||
 		    (size_t)written < pkt_len + 2) {


### PR DESCRIPTION
Stubby on Genode (BTW, Stubby has been ported to [Genode](https://genode.org/)) fails to use transports other than UDP. I've tracked this down to the use of `sendto` for TCP and TLS connections. We have not implemented TCP Fast Open in our Berkly sockets, and we would prefer that `write` would be used in place of `sendto`, because POSIX is quite vague on the `sendto` corner cases.

Ref https://github.com/genodelabs/genode/issues/2807