### PR TITLE
remove TLS1_3

### DIFF
--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -226,7 +226,6 @@ INLINE int _getdns_tls_version2openssl_version(getdns_tls_version_t v)
 	case GETDNS_TLS1  : return TLS1_VERSION;
 	case GETDNS_TLS1_1: return TLS1_1_VERSION;
 	case GETDNS_TLS1_2: return TLS1_2_VERSION;
-	case GETDNS_TLS1_3: return TLS1_3_VERSION;
 	default           : return TLS_MAX_VERSION;
 	}
 }


### PR DESCRIPTION
In the last switch-statement to get the tls version of the system, the line "case GETDNS_TLS1_3: return TLS1_3_VERSION;" throws an error when using the 'make' command.
Apparently, TLS1_3 was not defined.
Or the line is removed, or a declaration is made.
I removed the line and the compilation went fine.