### PR TITLE
Fix various build warnings uncovered on NetBSD w/pkgsrc.

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -55,6 +55,7 @@ typedef unsigned short in_port_t;
 
 #include <sys/stat.h>
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -1670,7 +1670,7 @@ getdns_str2dict(const char *str, getdns_dict **dict)
 	if (!str || !dict)
 		return GETDNS_RETURN_INVALID_PARAMETER;
 
-	while (*str && isspace(*str))
+	while (*str && isspace((unsigned char)*str))
 		str++;
 
 	if (*str != '{') {

--- a/src/tools/getdns_query.c
+++ b/src/tools/getdns_query.c
@@ -98,7 +98,7 @@ static int get_rrtype(const char *t)
 	if (strlen(t) > sizeof(buf) - 15)
 		return -1;
 	for (i = 14; *t && i < sizeof(buf) - 1; i++, t++)
-		buf[i] = *t == '-' ? '_' : toupper(*t);
+		buf[i] = *t == '-' ? '_' : toupper((unsigned char)*t);
 	buf[i] = '\0';
 
 	if (!getdns_str2int(buf, &rrtype))
@@ -123,7 +123,7 @@ static int get_rrclass(const char *t)
 	if (strlen(t) > sizeof(buf) - 16)
 		return -1;
 	for (i = 15; *t && i < sizeof(buf) - 1; i++, t++)
-		buf[i] = toupper(*t);
+		buf[i] = toupper((unsigned char)*t);
 	buf[i] = '\0';
 
 	if (!getdns_str2int(buf, &rrclass))

--- a/src/tools/getdns_server_mon.c
+++ b/src/tools/getdns_server_mon.c
@@ -130,7 +130,7 @@ static int get_rrtype(const char *t)
         if (strlen(t) > sizeof(buf) - 15)
                 return -1;
         for (i = 14; *t && i < sizeof(buf) - 1; i++, t++)
-                buf[i] = *t == '-' ? '_' : toupper(*t);
+                buf[i] = *t == '-' ? '_' : toupper((unsigned char)*t);
         buf[i] = '\0';
 
         if (!getdns_str2int(buf, &rrtype))

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -1428,9 +1428,9 @@ _getdns_validate_dname(const char* dname) {
                 break;
 	    case '\\':
 		s += 1;
-		if (isdigit(s[0])) {
+		if (isdigit((unsigned char)s[0])) {
 			/* octet value */
-			if (! isdigit(s[1]) && ! isdigit(s[2]))
+			if (! isdigit((unsigned char)s[1]) && ! isdigit((unsigned char)s[2]))
 				return GETDNS_RETURN_BAD_DOMAIN_NAME;
 
 			if ((s[0] - '0') * 100 +


### PR DESCRIPTION
The isxxxx() and toxxxx() functions have a limited well-defined
input value range, namely that of "unsigned char" plus EOF.  Cast
args accordingly.

Bring strncasecmp() into scope by including <strings.h>.