### PR TITLE
Fix builds in mingw32.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ format.  Note that this is different than the format of BIND.keys.
 
 When the root trust anchor is not installed in the default location and a DNSSEC query is done, getdns will try to use the trust anchors published here: http://data.iana.org/root-anchors/root-anchors.xml .
 It will validate these anchors with the ICANN Certificate Authority certificate following the procedure described in [RFC7958].
-The `root-anchors.xml` and `root-anchors.p7s` S/MIME signature will be cached in the `$HOME/.getdns` directory.
+The `root-anchors.xml` and `root-anchors.p7s` S/MIME signature will be cached in the `$HOME/.getdns` directory on Unixes, and the `%appdata%\getdns` directory on Windows.
 
-When using trust-anchors from the `root-anchors.xml` file, getdns will track the keys in the root DNSKEY rrset and store a copy in $HOME/.getdns/root.key.
+When using trust-anchors from the `root-anchors.xml` file, getdns will track the keys in the root DNSKEY rrset and store a copy in `$HOME/.getdns/root.key` on Unixes, and `%appdata%\getdns\root.key` on Windows.
 Only when the KSK DNSKEY's change, a new version of `root-anchors.xml` is tried to be retrieved from [data.iana.org](https://data.iana.org/root-anchors/).
 
 A installed trust-anchor from the default location (`/etc/unbound/getdns-root.key`) that fails to validate the root DNSKEY RRset, will also trigger the "Zero configuration DNSSEC" procedure described above.

--- a/configure.ac
+++ b/configure.ac
@@ -1514,9 +1514,20 @@ CFLAGS="$CFLAGS $LIBBSD_CFLAGS"
 ],[
 AC_MSG_WARN([libbsd not found or usable; using embedded code instead])
 ])
-AC_CHECK_DECLS([inet_pton,inet_ntop,strlcpy,arc4random,arc4random_uniform])
-AC_REPLACE_FUNCS(inet_pton)
-AC_REPLACE_FUNCS(inet_ntop)
+AC_CHECK_DECLS([inet_pton,inet_ntop,strlcpy,arc4random,arc4random_uniform], [], [], [
+AC_INCLUDES_DEFAULT
+#ifdef HAVE_WS2TCPIP_H
+#include <ws2tcpip.h>
+#endif
+])
+AS_IF([test "x$ac_cv_have_decl_inet_pton" = xyes],
+    [],
+    [AC_REPLACE_FUNCS(inet_pton)]
+)
+AS_IF([test "x$ac_cv_have_decl_inet_ntop" = xyes],
+    [],
+    [AC_REPLACE_FUNCS(inet_ntop)]
+)
 AC_REPLACE_FUNCS(strlcpy)
 AC_REPLACE_FUNCS(arc4random)
 AC_REPLACE_FUNCS(arc4random_uniform)

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -215,7 +215,7 @@ stubby.1: $(stubbysrcdir)/doc/stubby.1.in
 	sed -e "s|@ETCDIR@|$(stubbyconfdir)|g" $(stubbysrcdir)/doc/stubby.1.in > $@
 
 stubby.lo: $(stubbysrcdir)/src/stubby.c
-	$(LIBTOOL) --quiet --tag=CC --mode=compile $(CC) $(CFLAGS) $(WPEDANTICFLAG) -DSTUBBYCONFDIR=\"$(sysconfdir)/stubby\" -DRUNSTATEDIR=\"$(runstatedir)\" -c $(stubbysrcdir)/src/stubby.c -o $@
+	$(LIBTOOL) --quiet --tag=CC --mode=compile $(CC) $(CFLAGS) $(WPEDANTICFLAG) -DSTUBBYCONFDIR='"$(sysconfdir)/stubby"' -DRUNSTATEDIR='"$(runstatedir)"' -c $(stubbysrcdir)/src/stubby.c -o $@
 
 stubby: stubby.lo libgetdns.la $(STUBBY_XTRA_OBJS)
 	$(LIBTOOL) --tag=CC --mode=link $(CC) -o $@ stubby.lo $(STUBBY_XTRA_OBJS) $(STUBBY_LDFLAGS) libgetdns.la


### PR DESCRIPTION
On mingw64, configure does not find declarations for inet_ntop() and inet_pton(), but does find implementations, and so does not try to compile the compat versions.
On mingw32, configure finds neither declarations or implementations, and so tries to compile the compat versions. However, there are declarations in ws2tcpip.h, and these do not have the same prototype as compat. The build fails, complaining about conflicting types for inet_ntop().

The declarations in ws2tcpip.h are #defines to Windows functions InetNtopA() and InetPtonA(). Which is not good, but we're stuck with it. Try to work around this by including ws2tcpip.h in the headers while checking for declarations. Unfortunately it looks like you can't do that when checking for implementations and substituting compat versions when not found. So only do that if we don't find declarations; we're already making sure that ws2tcpip.h is included via config.h in source modules.