### PR TITLE
Two small trust anchor fetcher fixes

### DIFF
--- a/src/anchor.c
+++ b/src/anchor.c
@@ -750,7 +750,7 @@ static void tas_doc_read(getdns_context *context, tas_connection *a)
 		a->tcp.read_pos = a->tcp.read_buf;
 		a->tcp.to_read = sizeof(context->tas_hdr_spc);
 	}
-	GETDNS_SCHEDULE_EVENT(a->loop, a->fd, 50,
+	GETDNS_SCHEDULE_EVENT(a->loop, a->fd, 2000,
 	    getdns_eventloop_event_init(&a->event, a->req->owner,
 	    tas_read_cb, NULL, tas_reconnect_cb));
 	return;

--- a/src/anchor.c
+++ b/src/anchor.c
@@ -1086,11 +1086,11 @@ static void tas_connect(getdns_context *context, tas_connection *a)
 		}
 		if (a->state == TAS_RETRY_GET_PS7) {
 			buf_sz = sizeof(tas_write_p7s_buf)
-			       + 1 * (hostname_len - 2) + 1 * (path_len - 2) + 1;
+			       + 1 * (hostname_len - 2) + 1 * (path_len - 2);
 			fmt = tas_write_p7s_buf;
 		} else {
 			buf_sz = sizeof(tas_write_xml_p7s_buf)
-			       + 2 * (hostname_len - 2) + 2 * (path_len - 2) + 1;
+			       + 2 * (hostname_len - 2) + 2 * (path_len - 2);
 			fmt = tas_write_xml_p7s_buf;
 		}
 		if (!(write_buf = GETDNS_XMALLOC(context->mf, char, buf_sz))) {


### PR DESCRIPTION
This PR contains two small trust anchor fetcher fixes:
1) Fix for calculation of HTTP request buffer size in tas_connect() so
it no longer transmits the terminating NULL byte in its HTTP request
(and so the trust anchor server no longer sends an extra "501 Not implemented"
HTTP response),

2) Increase of anchor fetch timeout in tas_doc_read() from a very small 50ms to the
same as the other tas_read_cb() callback setter uses (2s).
This fixes fetching trust anchors on high-latency connections like 3G.
