### PR TITLE
Fix build error with gnu99 compilers

### DIFF
--- a/src/gnutls/tls-internal.h
+++ b/src/gnutls/tls-internal.h
@@ -53,7 +53,8 @@
 #define HAVE_TLS_CTX_CURVES_LIST	0
 #define HAVE_TLS_CONN_CURVES_LIST	0
 
-typedef struct getdns_log_config getdns_log_config;
+/* Forward declare type. */
+struct getdns_log_config;
 
 typedef struct _getdns_tls_context {
 	struct mem_funcs* mfs;
@@ -64,7 +65,7 @@ typedef struct _getdns_tls_context {
 	gnutls_protocol_t max_tls;
 	char* ca_trust_file;
 	char* ca_trust_path;
-	const getdns_log_config* log;
+	const struct getdns_log_config* log;
 } _getdns_tls_context;
 
 typedef struct _getdns_tls_connection {
@@ -81,7 +82,7 @@ typedef struct _getdns_tls_connection {
 	dane_query_t dane_query;
 	dane_state_t dane_state;
 	char* tlsa;
-	const getdns_log_config* log;
+	const struct getdns_log_config* log;
 } _getdns_tls_connection;
 
 typedef struct _getdns_tls_session {

--- a/src/openssl/tls-internal.h
+++ b/src/openssl/tls-internal.h
@@ -54,20 +54,21 @@
 
 #define GETDNS_TLS_MAX_DIGEST_LENGTH	(EVP_MAX_MD_SIZE)
 
-typedef struct sha256_pin sha256_pin_t;
-typedef struct getdns_log_config getdns_log_config;
+/* Forward declare type. */
+struct sha256_pin;
+struct getdns_log_config;
 
 typedef struct _getdns_tls_context {
 	SSL_CTX* ssl;
-	const getdns_log_config* log;
+	const struct getdns_log_config* log;
 } _getdns_tls_context;
 
 typedef struct _getdns_tls_connection {
 	SSL* ssl;
-	const getdns_log_config* log;
+	const struct getdns_log_config* log;
 #if defined(USE_DANESSL)
 	const char* auth_name;
-	const sha256_pin_t* pinset;
+	const struct sha256_pin* pinset;
 #endif
 } _getdns_tls_connection;
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -42,7 +42,7 @@
 
 /* Forward declare type. */
 struct sha256_pin;
-typedef struct sha256_pin sha256_pin_t;
+struct getdns_log_config;
 
 /* Additional return codes required by TLS abstraction. Internal use only. */
 #define GETDNS_RETURN_TLS_WANT_READ		((getdns_return_t) 420)
@@ -61,7 +61,7 @@ void _getdns_tls_init();
  * @paam log	pointer to context log config.
  * @return pointer to new context or NULL on error.
  */
-_getdns_tls_context* _getdns_tls_context_new(struct mem_funcs* mfs, const getdns_log_config* log);
+_getdns_tls_context* _getdns_tls_context_new(struct mem_funcs* mfs, const struct getdns_log_config* log);
 
 /**
  * Free a TLS context.
@@ -166,7 +166,7 @@ getdns_return_t _getdns_tls_context_set_ca(_getdns_tls_context* ctx, const char*
  * @paam log	pointer to connection log config.
  * @return pointer to new connection or NULL on error.
  */
-_getdns_tls_connection* _getdns_tls_connection_new(struct mem_funcs* mfs, _getdns_tls_context* ctx, int fd, const getdns_log_config* log);
+_getdns_tls_connection* _getdns_tls_connection_new(struct mem_funcs* mfs, _getdns_tls_context* ctx, int fd, const struct getdns_log_config* log);
 
 /**
  * Free a TLS connection.
@@ -314,7 +314,7 @@ getdns_return_t _getdns_tls_connection_setup_hostname_auth(_getdns_tls_connectio
  * @return GETDNS_RETURN_GOOD if all OK.
  * @return GETDNS_RETURN_INVALID_PARAMETER if conn is null or has no SSL.
  */
-getdns_return_t _getdns_tls_connection_set_host_pinset(_getdns_tls_connection* conn, const char* auth_name, const sha256_pin_t* pinset);
+getdns_return_t _getdns_tls_connection_set_host_pinset(_getdns_tls_connection* conn, const char* auth_name, const struct sha256_pin* pinset);
 
 /**
  * Get result of certificate verification.


### PR DESCRIPTION
Typedefs sha256_pin_t & getdns_log_config multiple declaration in context.h,
tls.h and tls_internal.h causes build error with some gnu99 compilers, even
if the redefinition is identical.
One possible way is to protect each occurence with ifdefs, but it seems too
brute, other one is to keep typedef in context.h only and use struct types
in recently added tls* scope.

Error example:
../libtool --quiet --tag=CC --mode=compile arm-brcm-linux-uclibcgnueabi-gcc
-std=gnu99 -I. -I. -I./util/auxiliary -I./tls -I./openssl -I./../stubby/src
-Wall -Wextra -D_BSD_SOURCE -D_DEFAULT_SOURCE ... -c ./convert.c -o convert.lo
In file included from ./context.h:53:0,
                 from ./util-internal.h:42,
                 from ./convert.c:50:
./tls.h:45:27: error: redefinition of typedef 'sha256_pin_t'
./openssl/tls-internal.h:57:27: note: previous declaration of 'sha256_pin_t' was here
In file included from ./util-internal.h:42:0,
                 from ./convert.c:50:
./context.h:133:3: error: redefinition of typedef 'sha256_pin_t'
./tls.h:45:27: note: previous declaration of 'sha256_pin_t' was here
./context.h:267:3: error: redefinition of typedef 'getdns_log_config'
./openssl/tls-internal.h:58:34: note: previous declaration of 'getdns_log_config' was here