### PR TITLE
Optimize local addresses enumeration with old uClibc

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -1161,7 +1161,7 @@ getdns_context_set_resolvconf(getdns_context *context, const char *resolvconf)
 
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family    = AF_UNSPEC;      /* Allow IPv4 or IPv6 */
-	hints.ai_socktype  = 0;              /* Datagram socket */
+	hints.ai_socktype  = SOCK_DGRAM;     /* Datagram socket */
 	hints.ai_flags     = AI_NUMERICHOST; /* No reverse name lookups */
 	hints.ai_protocol  = 0;              /* Any protocol */
 	hints.ai_canonname = NULL;
@@ -2736,7 +2736,7 @@ getdns_context_set_upstream_recursive_servers(struct getdns_context *context,
 	}
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family    = AF_UNSPEC;      /* Allow IPv4 or IPv6 */
-	hints.ai_socktype  = 0;              /* Datagram socket */
+	hints.ai_socktype  = SOCK_DGRAM;     /* Datagram socket */
 	hints.ai_flags     = AI_NUMERICHOST; /* No reverse name lookups */
 	hints.ai_protocol  = 0;              /* Any protocol */
 	hints.ai_canonname = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -978,6 +978,7 @@ getdns_return_t getdns_context_set_listen_addresses(
 
 	(void) memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family    = AF_UNSPEC;
+	hints.ai_socktype  = SOCK_DGRAM;
 	hints.ai_flags     = AI_NUMERICHOST;
 
 	for (i = 0; !r && i < new_set_count; i++) {


### PR DESCRIPTION
uClibc 0.9.30rc1 - 0.9.32rc5 has bug - getaddrinfo() does not accept numeric
service without any hints. As the related side effect, hint struct with
ai_socktype == 0 (unspec) and ai_protocol == 0 (unpsec) gives the same
EAI_SERVICE error instead of same address with different proto enumebration.
For more details please refer https://bugs.busybox.net/show_bug.cgi?id=3841 and
https://git.uclibc.org/uClibc/commit/?id=bc3be18145e4d57e7268506f123c0f0f373a15e2

Since 0.9.3x uClibc versions are still not somewhat unique in embedded (issue
getdnsapi/stubby/issues/124 as an example) and non-zero ai_socktype allows
to avoid address dups for each supported UDP/TCP/etc proto, seems worth to
have it specified, as a minor memory allocation optimization at least.

SOCK_DGRAM vs SOCK_STREAM choice doesn't really matter here, both are actually
used for DNS and both are non-zero, no difference is expected on *nix. So
SOCK_DGRAM selected due original comment only.