### PR TITLE
Restore opportunistic connections, and some GnuTLS tweaks

### DIFF
--- a/src/gnutls/tls.c
+++ b/src/gnutls/tls.c
@@ -126,8 +126,9 @@ static int set_connection_ciphers(_getdns_tls_connection* conn)
 	if (!min) min = conn->ctx->min_tls;
 	if (!max) max = conn->ctx->max_tls;
 
+	pri = getdns_priappend(conn->mfs, pri, "-VERS-ALL");
 	if (!min && !max) {
-		pri = getdns_priappend(conn->mfs, pri, "+VERS-TLS-ALL");
+		pri = getdns_priappend(conn->mfs, pri, "+VERS-TLS1.2:+VERS-TLS1.3");
 	} else {
 		if (!max) max = GNUTLS_TLS_VERSION_MAX;
 

--- a/src/gnutls/tls.c
+++ b/src/gnutls/tls.c
@@ -102,7 +102,7 @@ static int set_connection_ciphers(_getdns_tls_connection* conn)
 	char* pri = NULL;
 	int res;
 
-	pri = getdns_priappend(conn->mfs, pri, "NONE:+COMP-ALL:+SIGN-RSA-SHA384");
+	pri = getdns_priappend(conn->mfs, pri, "NONE:+COMP-ALL:+SIGN-ALL");
 
 	if (conn->cipher_suites)
 		pri = getdns_priappend(conn->mfs, pri, conn->cipher_suites);


### PR DESCRIPTION
With regards to the final change, this deliberately provokes a policy question of whether users should be able to reduce the minimum TLS version below 1.2.

Historically this wasn't possible with older OpenSSL, because we used TLSv1_2_client_method(), but with modern OpenSSL we use TLS_client_method().

The defaults explicitly set a minimum TLS version of 1.2. The user must deliberately specify no minimum TLS version. In this case, this change means that GnuTLS behaviour and modern OpenSSL behaviour diverge - GnuTLS applies a minimum of TLS1.2, OpenSSL negotiates the highest TLS version supported by both client and server - as was the GnuTLS behaviour before the change - but will go below TLS1.2 if necessary, whereas GnuTLS will fail to connect.