### PR TITLE
Update mailing list references

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,7 @@ Support
 
 ## Mailing lists
 
-We have a [getdns users list](https://getdnsapi.net/mailman/listinfo/users) for this implementation.
-
-The [getdns-api mailing list](https://getdnsapi.net/mailman/listinfo/spec) is a good place to engage in discussions regarding the design of the API.
+We have a [getdns users list](https://lists.getdnsapi.net/mailman/listinfo/users) for this implementation.
 
 ## Tickets and Bug Reports
 
@@ -368,4 +366,4 @@ Contributors
 
 Acknowledgements
 ================
-The development team explicitly acknowledges Paul Hoffman for his initiative and efforts to develop a consensus based DNS API. We would like to thank the participants of the [mailing list](https://getdnsapi.net/mailman/listinfo/spec) for their contributions.
+The development team explicitly acknowledges Paul Hoffman for his initiative and efforts to develop a consensus based DNS API. We would like to thank the participants of the getdns-api mailing list (discontinued) for their contributions.


### PR DESCRIPTION
The getdns users mailing list has been changed from `users@getdnsapi.net` to `users@lists.getdnsapi.net`. `spec@getdnsapi.net` was merged with `users@getdnsapi.net` as requested by @wtoorop. I've updated `README.md` to reflect this change. Please consider pulling these changes.