### PR TITLE
Get tests passing on Bionic and OSX

### DIFF
--- a/src/test/tpkg/125-valgrind-checks.tpkg/125-valgrind-checks.test
+++ b/src/test/tpkg/125-valgrind-checks.tpkg/125-valgrind-checks.test
@@ -20,8 +20,20 @@ localhost.
 -S
 -X
 EOT
+cat >125.supp <<EOT
+{
+   <bionic_leak_nettle_ecc_point_init>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:__gmp_default_allocate
+   fun:_nettle_gmp_alloc_limbs
+   fun:nettle_ecc_point_init
+   obj:/usr/lib/x86_64-linux-gnu/libunbound.so.2.5.6
+}
+EOT
 (
-	if ! valgrind -v --log-file=valgrind.log --leak-check=full --error-exitcode=1 --track-origins=yes "${GETDNS_QUERY}" -F queries -f "${TPKG_NAME}.ds" +dnssec_return_validation_chain
+	if ! valgrind -v --log-file=valgrind.log --suppressions=125.supp --leak-check=full --error-exitcode=1 --track-origins=yes "${GETDNS_QUERY}" -F queries -f "${TPKG_NAME}.ds" +dnssec_return_validation_chain
 	then
 		exit 1
 	fi

--- a/src/test/tpkg/275-server-capabilities.tpkg/275-server-capabilities.dsc
+++ b/src/test/tpkg/275-server-capabilities.tpkg/275-server-capabilities.dsc
@@ -5,7 +5,7 @@ CreationDate: wo 19 apr 2017 10:01:58 CEST
 Maintainer: Hoda Rohani
 Category: 
 Component:
-CmdDepends: 
+CmdDepends: valgrind
 Depends: 200-stub-only-compile-install.tpkg
 Help:
 Pre: 275-server-capabilities.pre

--- a/src/test/tpkg/280-limit_outstanding_queries.tpkg/280-limit_outstanding_queries.dsc
+++ b/src/test/tpkg/280-limit_outstanding_queries.tpkg/280-limit_outstanding_queries.dsc
@@ -5,7 +5,7 @@ CreationDate: Tue Mar 14 10:43:45 CET 2017
 Maintainer: Willem Toorop
 Category: Resource depletion
 Component:
-CmdDepends: 
+CmdDepends: valgrind
 Depends: 200-stub-only-compile-install.tpkg
 Help:
 Pre: 280-limit_outstanding_queries.pre

--- a/src/test/tpkg/285-out_of_filedescriptors.tpkg/285-out_of_filedescriptors.dsc
+++ b/src/test/tpkg/285-out_of_filedescriptors.tpkg/285-out_of_filedescriptors.dsc
@@ -5,7 +5,7 @@ CreationDate: ma 20 mrt 2017 15:17:45 CET
 Maintainer: Willem Toorop
 Category: Resource depletion
 Component:
-CmdDepends: 
+CmdDepends: valgrind
 Depends: 200-stub-only-compile-install.tpkg
 Help:
 Pre: 285-out_of_filedescriptors.pre


### PR DESCRIPTION
Some minor fixes to tests.

These enables the suite to pass without failures on up to date Bionic and on OSX.

OSX omits valgrind, as there is not current valgrind support for Mojave.