### PR TITLE
Tighten Nettle version checking, and fix build issue with Nettle >= 3.4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,14 +365,19 @@ endif()
 # handle digital signature algorithms. GnuTLS uses Nettle internally.
 if (USE_GNUTLS)
   find_package(GnuTLS "3.5.0" REQUIRED)
-  find_package(Nettle REQUIRED)
+  find_package(Nettle "3.2" REQUIRED)
 
   set(tlsdir "gnutls")
   set(HAVE_NETTLE 1)
 
   set(CMAKE_REQUIRED_INCLUDES ${NETTLE_INCLUDE_DIR})
+set(CMAKE_REQUIRED_LIBRARIES ${NETTLE_LIBRARIES})
   check_include_file(nettle/dsa-compat.h HAVE_NETTLE_DSA_COMPAT_H)
   check_include_file(nettle/eddsa.h HAVE_NETTLE_EDDSA_H)
+
+  # API change in Nettle 3.4.
+  check_symbol_exists(nettle_get_secp_256r1 "nettle/ecc-curve.h" HAVE_NETTLE_GET_SECP_256R1)
+  check_symbol_exists(nettle_get_secp_384r1 "nettle/ecc-curve.h" HAVE_NETTLE_GET_SECP_384R1)
 endif()
 
 # Sort out what signature algorithms can be used.
@@ -390,7 +395,7 @@ endif ()
 
 if (USE_ED448)
   if (USE_GNUTLS)
-    message(WARNING "ED448 enabled and Nettle does not support it. Disabled.")
+    message(WARNING "ED448 enabled and Nettle support not implemented. Disabled.")
     unset(USE_ED448)
   elseif (NOT HAVE_SSL_ED448)
     message(WARNING "ED448 enabled and OpenSSL does not support it. Disabled.")

--- a/cmake/include/cmakeconfig.h.in
+++ b/cmake/include/cmakeconfig.h.in
@@ -79,6 +79,9 @@
 
 #cmakedefine HAVE_HMAC_CTX_NEW		1
 
+#cmakedefine HAVE_NETTLE_GET_SECP_256R1	1
+#cmakedefine HAVE_NETTLE_GET_SECP_384R1	1
+
 #cmakedefine HAVE_TLS_CLIENT_METHOD	1
 
 #cmakedefine HAVE_OPENSSL_VERSION_NUM	1

--- a/src/tls/val_secalgo.c
+++ b/src/tls/val_secalgo.c
@@ -1726,7 +1726,11 @@ _verify_nettle_ecdsa(sldns_buffer* buf, unsigned int digest_size, unsigned char*
 		{
 			uint8_t digest[SHA256_DIGEST_SIZE];
 			mpz_t x, y;
+#ifdef HAVE_NETTLE_GET_SECP_256R1
+			nettle_ecc_point_init(&pubkey, nettle_get_secp_256r1());
+#else
 			nettle_ecc_point_init(&pubkey, &nettle_secp_256r1);
+#endif
 			nettle_mpz_init_set_str_256_u(x, SHA256_DIGEST_SIZE, key);
 			nettle_mpz_init_set_str_256_u(y, SHA256_DIGEST_SIZE, key+SHA256_DIGEST_SIZE);
 			nettle_mpz_set_str_256_u(signature.r, SHA256_DIGEST_SIZE, sigblock);
@@ -1743,7 +1747,11 @@ _verify_nettle_ecdsa(sldns_buffer* buf, unsigned int digest_size, unsigned char*
 		{
 			uint8_t digest[SHA384_DIGEST_SIZE];
 			mpz_t x, y;
+#ifdef HAVE_NETTLE_GET_SECP_384R1
+			nettle_ecc_point_init(&pubkey, nettle_get_secp_384r1());
+#else
 			nettle_ecc_point_init(&pubkey, &nettle_secp_384r1);
+#endif
 			nettle_mpz_init_set_str_256_u(x, SHA384_DIGEST_SIZE, key);
 			nettle_mpz_init_set_str_256_u(y, SHA384_DIGEST_SIZE, key+SHA384_DIGEST_SIZE);
 			nettle_mpz_set_str_256_u(signature.r, SHA384_DIGEST_SIZE, sigblock);


### PR DESCRIPTION
Nettle 3.4 introduced accessor functions for obtaining nettle_secp_256r1 and nettle_secp_384r1. Use them if present.

Fixes #458