### PR TITLE
Fix uninitialized value in tls_create_object

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -926,6 +926,7 @@ upstream_init(getdns_upstream *upstream,
 	/* For sharing a socket to this upstream with TCP  */
 	upstream->fd       = -1;
 	upstream->expires  = 0;
+	upstream->tls_fallback_ok = 0;
 	upstream->tls_obj  = NULL;
 	upstream->tls_session = NULL;
 	upstream->tls_cipher_list = NULL;


### PR DESCRIPTION
On the first call to tls_create_object (stub.c), tls_fallback_ok is read
before being initialized. This patch initializes tls_fallback_ok to 0 in
upstream_init (context.c)

Valgrind complains about the uninitialized value:
==14774== Conditional jump or move depends on uninitialised value(s)
==14774==    at 0x1528C3: tls_create_object (stub.c:900)
==14774==    by 0x1556AD: upstream_connect (stub.c:2065)
==14774==    by 0x15582E: upstream_find_for_transport (stub.c:2109)
==14774==    by 0x1558B7: upstream_find_for_netreq (stub.c:2130)
==14774==    by 0x156027: _getdns_submit_stub_request (stub.c:2296)
==14774==    by 0x1421C8: _getdns_submit_netreq (general.c:478)
==14774==    by 0x14261D: getdns_general_ns (general.c:636)
==14774==    by 0x142905: _getdns_general_loop (general.c:731)
==14774==    by 0x1432FB: getdns_general (general.c:888)
==14774==    by 0x118B94: incoming_request_handler (stubby.c:692)
==14774==    by 0x14F46B: udp_read_cb (server.c:762)
==14774==    by 0x15C86B: poll_read_cb (poll_eventloop.c:295)
==14774==  Uninitialised value was created by a heap allocation
==14774==    at 0x483877F: malloc (vg_replace_malloc.c:309)
==14774==    by 0x123CCF: upstreams_create (context.c:581)
==14774==    by 0x128B24: getdns_context_set_upstream_recursive_servers (context.c:2760)
==14774==    by 0x12DBFE: _getdns_context_config_setting (context.c:4646)
==14774==    by 0x12FF47: getdns_context_config (context.c:4769)
==14774==    by 0x1178C2: parse_config (stubby.c:297)
==14774==    by 0x117B24: parse_config_file (stubby.c:343)
==14774==    by 0x11919F: main (stubby.c:833)