### PR TITLE
Various small fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	branch = develop
 [submodule "src/ssl_dane"]
 	path = src/ssl_dane
-	url = https://github.com/banburybill/ssl_dane
-	branch = feature/windows-native-build
+	url = https://github.com/getdnsapi/ssl_dane
+	branch = getdns

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,9 +489,19 @@ if (NOT ENABLE_STUB_ONLY)
 
   set(CMAKE_REQUIRED_INCLUDES ${LIBUNBOUND_INCLUDE_DIR})
   set(CMAKE_REQUIRED_LIBRARIES ${LIBUNBOUND_LIBRARIES})
-  check_include_file(unbound-event.h HAVE_UNBOUND_EVENT_H)
-  check_symbol_exists(ub_ctx_create_ub_event "unbound-event.h" HAVE_UNBOUND_EVENT_API)
-  check_symbol_exists(ub_ctx_set_stub "unbound-event.h" HAVE_UB_CTX_SET_STUB)
+
+  check_symbol_exists(ub_ctx_set_stub "unbound.h" HAVE_UB_CTX_SET_STUB)
+
+  if (ENABLE_UNBOUND_EVENT_API)
+    check_include_file(unbound-event.h HAVE_UNBOUND_EVENT_H)
+    check_symbol_exists(ub_ctx_create_ub_event "unbound-event.h" HAVE_UNBOUND_EVENT_API)
+  endif ()
+else ()
+  # Ensure we're not using libunbound items.
+  set(HAVE_LIBUNBOUND 0)
+  set(HAVE_UNBOUND_EVENT_H 0)
+  set(HAVE_UNBOUND_EVENT_API 0)
+  set(HAVE_UB_CTX_SET_STUB 0)
 endif ()
 
 # Event loop extension

--- a/src/util/lookup3.c
+++ b/src/util/lookup3.c
@@ -53,21 +53,18 @@ on 1 byte), but shoehorning those bytes into integers efficiently is messy.
 #include "util/storage/lookup3.h"
 #include <stdio.h>      /* defines printf for tests */
 #include <time.h>       /* defines time_t for timings in the test */
-/*#include <stdint.h>     defines uint32_t etc  (from config.h) */
-#include <sys/param.h>  /* attempt to define endianness */
-#ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h> /* attempt to define endianness (solaris) */
-#endif
-#if defined(linux) || defined(__OpenBSD__)
-#  ifdef HAVE_ENDIAN_H
-#    include <endian.h>    /* attempt to define endianness */
-#  else
-#    include <machine/endian.h> /* on older OpenBSD */
-#  endif
-#endif
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
-#include <sys/endian.h> /* attempt to define endianness */
-#endif
+
+#if defined(HAVE_TARGET_ENDIANNESS)
+# if defined(TARGET_IS_BIG_ENDIAN)
+#  define HASH_LITTLE_ENDIAN 0
+#  define HASH_BIG_ENDIAN 1
+# else
+#  define HASH_LITTLE_ENDIAN 1
+#  define HASH_BIG_ENDIAN 0
+# endif
+#else
+# error "Target endianness required."
+#endif /* defined(HAVE_TARGET_ENDIANNESS) */
 
 /* random initial value */
 static uint32_t raninit = (uint32_t)0xdeadbeef;
@@ -77,36 +74,6 @@ hash_set_raninit(uint32_t v)
 {
 	raninit = v;
 }
-
-/*
- * My best guess at if you are big-endian or little-endian.  This may
- * need adjustment.
- */
-#if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && \
-     __BYTE_ORDER == __LITTLE_ENDIAN) || \
-    (defined(i386) || defined(__i386__) || defined(__i486__) || \
-     defined(__i586__) || defined(__i686__) || defined(vax) || defined(MIPSEL) || defined(__x86))
-# define HASH_LITTLE_ENDIAN 1
-# define HASH_BIG_ENDIAN 0
-#elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && \
-       __BYTE_ORDER == __BIG_ENDIAN) || \
-      (defined(sparc) || defined(__sparc) || defined(__sparc__) || defined(POWERPC) || defined(mc68000) || defined(sel))
-# define HASH_LITTLE_ENDIAN 0
-# define HASH_BIG_ENDIAN 1
-#elif defined(_MACHINE_ENDIAN_H_)
-/* test for machine_endian_h protects failure if some are empty strings */
-# if defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && _BYTE_ORDER == _BIG_ENDIAN
-#  define HASH_LITTLE_ENDIAN 0
-#  define HASH_BIG_ENDIAN 1
-# endif
-# if defined(_BYTE_ORDER) && defined(_LITTLE_ENDIAN) && _BYTE_ORDER == _LITTLE_ENDIAN
-#  define HASH_LITTLE_ENDIAN 1
-#  define HASH_BIG_ENDIAN 0
-# endif /* _MACHINE_ENDIAN_H_ */
-#else
-# define HASH_LITTLE_ENDIAN 0
-# define HASH_BIG_ENDIAN 0
-#endif
 
 #define hashsize(n) ((uint32_t)1<<(n))
 #define hashmask(n) (hashsize(n)-1)


### PR DESCRIPTION
1. Revise recent update to lookup3.c to restore building on Windows.
1. CMake `ub_cts_set_stub` location correction.
1. Don't enable Unbound event API if explicitly disabled.
1. If stub only, explicitly disable all `libunbound` items. We may know `libunbound` is installed from a former configuration run, but if we switch to stub only, we don't want to use it.

There's also a merge. This is an upstream change merged during work on the above.