### PR TITLE
only check for and process read/write events if status is success

### DIFF
--- a/src/extension/libuv.c
+++ b/src/extension/libuv.c
@@ -134,24 +134,25 @@ static void
 getdns_libuv_cb(uv_poll_t *poll, int status, int events)
 {
 	getdns_eventloop_event *el_ev = (getdns_eventloop_event *)poll->data;
-	(void)status;
 
-	if (events & UV_READABLE) {
-		assert(el_ev->read_cb);
-		DEBUG_UV("enter libuv_read_cb(el_ev = %p, el_ev->ev = %p)\n"
-				, el_ev, el_ev->ev);
-		el_ev->read_cb(el_ev->userarg);
-		DEBUG_UV("exit  libuv_read_cb(el_ev = %p, el_ev->ev = %p)\n"
-				, el_ev, el_ev->ev);
-	} else if (events & UV_WRITABLE) {
-		assert(el_ev->write_cb);
-		DEBUG_UV("enter libuv_write_cb(el_ev = %p, el_ev->ev = %p)\n"
-				, el_ev, el_ev->ev);
-		el_ev->write_cb(el_ev->userarg);
-		DEBUG_UV("exit  libuv_write_cb(el_ev = %p, el_ev->ev = %p)\n"
-				, el_ev, el_ev->ev);
-	} else {
-		assert(ASSERT_UNREACHABLE);
+	if (status == 0) {
+		if (events & UV_READABLE) {
+			assert(el_ev->read_cb);
+			DEBUG_UV("enter libuv_read_cb(el_ev = %p, el_ev->ev = %p)\n"
+					, el_ev, el_ev->ev);
+			el_ev->read_cb(el_ev->userarg);
+			DEBUG_UV("exit  libuv_read_cb(el_ev = %p, el_ev->ev = %p)\n"
+					, el_ev, el_ev->ev);
+		} else if (events & UV_WRITABLE) {
+			assert(el_ev->write_cb);
+			DEBUG_UV("enter libuv_write_cb(el_ev = %p, el_ev->ev = %p)\n"
+					, el_ev, el_ev->ev);
+			el_ev->write_cb(el_ev->userarg);
+			DEBUG_UV("exit  libuv_write_cb(el_ev = %p, el_ev->ev = %p)\n"
+					, el_ev, el_ev->ev);
+		} else {
+			assert(ASSERT_UNREACHABLE);
+		}
 	}
 }
 


### PR DESCRIPTION
Unlike libevent, libuv has a separate status flag for errors that occur while polling. Thus there's an edge case today where an error during poll will call `getdns_libuv_cb` with a status < 1 and an event that is neither UV_READABLE nor UV_WRITABLE, triggering an ASSERT_UNREACHABLE crash.

Work around this by only calling our read/write callbacks if the poll status is non error.