### PR TITLE
Some Windows behaviour fixes.

### DIFF
--- a/src/compat/mkstemp.c
+++ b/src/compat/mkstemp.c
@@ -39,5 +39,5 @@ int mkstemp(char *template)
 {
 		if (_mktemp_s(template, strlen(template) + 1) != 0)
 				return -1;
-		return open(template, _O_CREAT | _O_EXCL, _S_IWRITE);
+		return open(template, _O_CREAT | _O_EXCL | _O_RDWR, _S_IWRITE | _S_IREAD);
 }

--- a/src/context.c
+++ b/src/context.c
@@ -4889,7 +4889,7 @@ FILE *_getdns_context_get_priv_fp(
 		_getdns_log(&context->log
 		           , GETDNS_LOG_SYS_ANCHOR, GETDNS_LOG_INFO
 		           , "Error opening \"%s\": %s\n"
-			   , path, _getdns_errnostr());
+			   , path, _getdns_fileerrnostr());
 	return f;
 }
 
@@ -4968,31 +4968,31 @@ int _getdns_context_write_priv_file(getdns_context *context,
 		_getdns_log(&context->log
 		           , GETDNS_LOG_SYS_ANCHOR, GETDNS_LOG_INFO
 		           , "Could not create temporary file \"%s\": %s\n"
-			   , tmpfn, _getdns_errnostr());
+			   , tmpfn, _getdns_fileerrnostr());
 
 	else if (!(f = fdopen(fd, "w")))
 		_getdns_log(&context->log
 		           , GETDNS_LOG_SYS_ANCHOR, GETDNS_LOG_ERR
 		           , "Error opening temporary file \"%s\": %s\n"
-			   , tmpfn, _getdns_errnostr());
+			   , tmpfn, _getdns_fileerrnostr());
 
 	else if (fwrite(content->data, 1, content->size, f) < content->size)
 		_getdns_log(&context->log
 		           , GETDNS_LOG_SYS_ANCHOR, GETDNS_LOG_ERR
 		           , "Error writing to temporary file \"%s\": %s\n"
-			   , tmpfn, _getdns_errnostr());
+			   , tmpfn, _getdns_fileerrnostr());
 
-	else if (fclose(f) < 0)
+	else if (fclose(f))
 		_getdns_log(&context->log
 		           , GETDNS_LOG_SYS_ANCHOR, GETDNS_LOG_ERR
-		           , "Error closing temporary file \"%s\": %s\n"
-			   , tmpfn, _getdns_errnostr());
+		           , "Error closing temporary file \"%s\": %s (%p)\n"
+			    , tmpfn, _getdns_fileerrnostr(), f);
 
 	else if (rename(tmpfn, path) < 0)
 		_getdns_log(&context->log
 		           , GETDNS_LOG_SYS_ANCHOR, GETDNS_LOG_ERR
 		           , "Error renaming temporary file \"%s\" to \"%s\""
-			     ": %s\n", tmpfn, path, _getdns_errnostr());
+			     ": %s\n", tmpfn, path, _getdns_fileerrnostr());
 	else {
 		context->can_write_appdata = PROP_ABLE;
 		return 1;
@@ -5045,7 +5045,7 @@ int _getdns_context_can_write_appdata(getdns_context *context)
 		_getdns_log(&context->log
 		           , GETDNS_LOG_SYS_ANCHOR, GETDNS_LOG_ERR
 		           , "Error unlinking write test file: \"%s\": %s\n"
-			   , path, _getdns_errnostr());
+			   , path, _getdns_fileerrnostr());
 	return 1;
 }
 

--- a/src/platform.c
+++ b/src/platform.c
@@ -166,6 +166,11 @@ const char *_getdns_strerror(DWORD errnum)
 	}
 }
 
+const char *_getdns_filestrerror(int errnum)
+{
+	return strerror(errnum);
+}
+
 #else
 
 void _getdns_perror(const char *str)

--- a/src/platform.h
+++ b/src/platform.h
@@ -60,6 +60,7 @@ typedef u_short sa_family_t;
 #define _getdns_socketerror() (WSAGetLastError())
 
 const char *_getdns_strerror(DWORD errnum);
+const char *_getdns_filestrerror(int errnum);
 #else /* USE_WINSOCK */
 
 #ifndef HAVE_SYS_POLL_H
@@ -132,10 +133,13 @@ const char *_getdns_strerror(DWORD errnum);
 #define _getdns_socketerror() (errno)
 
 const char *_getdns_strerror(int errnum);
+#define _getdns_filestrerror(errnum) (_getdns_strerror(errnum))
 #endif
 
 void _getdns_perror(const char *str);
 
+#define _getdns_fileerror() (errno)
+#define _getdns_fileerrnostr() (_getdns_filestrerror(_getdns_fileerror()))
 #define _getdns_errnostr() (_getdns_strerror(_getdns_socketerror()))
 #define _getdns_error_wants_retry(X) (  (X) != 0 \
                                      && (  (X) == _getdns_EINTR \


### PR DESCRIPTION
DNSSEC validation on Windows doesn't work at present. These fixes move us along the way, but do not reach the goal. Next hurdles:

1. rename() at context.c line 4991. rename() on Windows fails if the destination file exists.
2. Windows throws an exception in the close() at line 554 in anchor.c (called from tas_read_cb()) because the fd is not open.

