### PR TITLE
CMakeLists.txt: use canonical GNUInstallDirs variable for docdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1101,9 +1101,8 @@ endif ()
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/getdns DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man3 DESTINATION share/man)
 
-set(docdir share/doc/getdns)
-install(FILES AUTHORS ChangeLog COPYING LICENSE NEWS README.md DESTINATION ${docdir})
-install(FILES spec/index.html DESTINATION ${docdir}/spec)
+install(FILES AUTHORS ChangeLog COPYING LICENSE NEWS README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES spec/index.html DESTINATION ${CMAKE_INSTALL_DOCDIR}/spec)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/getdns.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 install(CODE "message(\"\


### PR DESCRIPTION
We use the GNUInstallDir variables for the rest of the build system
locations, so let's use CMAKE_INSTALL_DOCDIR too to allow customisation
downstream.

(In Gentoo, we set it to the exact package version including downstream-only
revisions.)

Signed-off-by: Sam James <sam@gentoo.org>