### PR TITLE
Category: Strengthen LibIDN2 version determination during cmake run

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* 2022-07-20
+  * Strengthen version determination for Libidn2 during cmake processing.
+
 * 2021-06-04: Version 1.7.0
   * Make TLS Handshake timeout max 4/5th of timeout for the query,
     just like connection setup timeout was, so fallback transport

--- a/cmake/modules/FindLibidn2.cmake
+++ b/cmake/modules/FindLibidn2.cmake
@@ -53,8 +53,8 @@ if (LIBIDN2_INCLUDE_DIR AND LIBIDN2_LIBRARY)
   endif ()
 
   if (NOT LIBIDN2_VERSION AND LIBIDN2_INCLUDE_DIR AND EXISTS "${LIBIDN2_INCLUDE_DIR}/unbound.h")
-    file(STRINGS "${LIBIDN2_INCLUDE_DIR}/idn2.h" LIBIDN2_H REGEX "^#define IDN2_VERSION ")
-    string(REGEX REPLACE "^.*IDN2_VERSION \"([0-9.]+)\".*$" "\\1" LIBIDN2_VERSION "${LIBIDN2_H}")
+    file(STRINGS "${LIBIDN2_INCLUDE_DIR}/idn2.h" LIBIDN2_H REGEX "^[ \t]*#[ \t]*define[ \t]+IDN2_VERSION[ \t]")
+    string(REGEX REPLACE "^.*IDN2_VERSION[ \t]+\"([0-9.]+)\".*$" "\\1" LIBIDN2_VERSION "${LIBIDN2_H}")
   endif ()
 endif()
 


### PR DESCRIPTION
Contains patch to make LibIDN2 2.3.3 discoverable during the cmake step.