### PR TITLE
fix build issue

### DIFF
--- a/src/gldns/parse.c
+++ b/src/gldns/parse.c
@@ -13,6 +13,7 @@
 #include "gldns/gbuffer.h"
 
 #include <limits.h>
+#include <stdlib.h>
 #include <strings.h>
 
 gldns_lookup_table gldns_directive_types[] = {


### PR DESCRIPTION
fix build error as below:
```
/tmp/getdns-20220820-35872-b98qtd/getdns-1.7.2/src/gldns/parse.c:250:16: error: implicitly declaring library function 'free' with type 'void (void *)' [-Werror,-Wimplicit-function-declaration]
               free(fkeyword);
               ^
```

relates to Homebrew/homebrew-core#108544
