### PR TITLE
Increase CMake required version 3.5 -> 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 if (POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)


### PR DESCRIPTION
Hi,

Commit 777e0b245c510e273e5ba917939a21778cb060f2 introduced `cmake_path` which has been added to Cmake in 3.20 only (https://cmake.org/cmake/help/git-master/command/cmake_path.html)

This should only make the error message more explicit.

Best regards,
