### PR TITLE
fix windows build

### DIFF
--- a/src/gldns/parse.c
+++ b/src/gldns/parse.c
@@ -13,7 +13,7 @@
 #include "gldns/gbuffer.h"
 
 #include <limits.h>
-#include <strings.h>
+#include <stdlib.h>
 
 gldns_lookup_table gldns_directive_types[] = {
         { GLDNS_DIR_TTL, "$TTL" },

--- a/src/gldns/parseutil.c
+++ b/src/gldns/parseutil.c
@@ -14,8 +14,12 @@
 
 #include "config.h"
 #include "gldns/parseutil.h"
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif
+#ifdef HAVE_TIME_H
 #include <time.h>
+#endif
 #include <ctype.h>
 
 gldns_lookup_table *


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/pull/34188 tell that on windows 
```
D:\buildtrees\getdns\src\getdns-1-9f99f372dc.clean\src\gldns\parseutil.c(17): fatal error C1083: Cannot open include file: 'sys/time.h': No such file or directory
D:\buildtrees\getdns\src\getdns-1-9f99f372dc.clean\src\gldns\parse.c(16): fatal error C1083: Cannot open include file: 'strings.h': No such file or directory
```
this patch fix it.