### PR TITLE
avoid phoning home to creativecommons.org when reading docs

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2495,10 +2495,7 @@ deallocates them.</p>
 
 <hr width=90%>
 
-<p><a rel="license" href="https://creativecommons.org/licenses/by/3.0/deed.en_US"><img alt="Creative
-Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/80x15.png"
-/></a><br />This work is licensed under a <a rel="license"
-href="https://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0
-Unported License</a>.</p>
+<p><a rel="license" href="https://creativecommons.org/licenses/by/3.0/deed.en_US">
+Creative Commons Attribution 3.0 Unported License</a>.</p>
 
 </body></html>


### PR DESCRIPTION
Hi maintainers!

Would you consider removing the image link to Creative Commons from the bottom of the API documentation? If this documentation is installed on users' filesystems they might reasonably expect to be able to browse it without initiating a network connection to a third party!

The source of this change is a long-standing Debian patch (see commit log) which I have fixed and simplified.

Thanks,
Andrew

P.S. I like the way this document has been produced - nicely done!